### PR TITLE
fix: D global requires grad were not set true before backward

### DIFF
--- a/models/cycle_gan_model.py
+++ b/models/cycle_gan_model.py
@@ -157,15 +157,15 @@ class CycleGANModel(BaseModel):
                 
             ###Making groups
             self.networks_groups = []
-            discriminators=["netD_A","netD_B"]
+            discriminators=["D_A","D_B"]
             if opt.netD_global != "none":
-                discriminators += ["netD_A_global","netD_B_global"]
+                discriminators += ["D_A_global","D_B_global"]
                 self.D_global_loss=loss.DiscriminatorGANLoss(opt,self.netD_A_global,self.device)
 
             self.group_G = NetworkGroup(networks_to_optimize=["G_A","G_B"],forward_functions=["forward"],backward_functions=["compute_G_loss"],loss_names_list=["loss_names_G"],optimizer=["optimizer_G"],loss_backward=["loss_G"],networks_to_ema=["G_A","G_B"])
             self.networks_groups.append(self.group_G)
 
-            self.group_D = NetworkGroup(networks_to_optimize=["D_A","D_B"],forward_functions=None,backward_functions=["compute_D_loss"],loss_names_list=["loss_names_D"],optimizer=["optimizer_D"],loss_backward=["loss_D"])
+            self.group_D = NetworkGroup(networks_to_optimize=discriminators,forward_functions=None,backward_functions=["compute_D_loss"],loss_names_list=["loss_names_D"],optimizer=["optimizer_D"],loss_backward=["loss_D"])
             self.networks_groups.append(self.group_D)
             
 


### PR DESCRIPTION
Before processing backward, networks `requires_grad` attributes need to be set True, it was't done for `D_global` in cyclegan. 