### PR TITLE
feat: new f_s resnet50 pretrained on BDD100k

### DIFF
--- a/models/configs/resnet50/dnl_r50-d8.py
+++ b/models/configs/resnet50/dnl_r50-d8.py
@@ -1,0 +1,48 @@
+# model settings
+norm_cfg = dict(type="SyncBN", requires_grad=True)
+model = dict(
+    type="EncoderDecoder",
+    pretrained="open-mmlab://resnet50_v1c",
+    backbone=dict(
+        type="ResNetV1c",
+        depth=50,
+        num_stages=4,
+        out_indices=(0, 1, 2, 3),
+        dilations=(1, 1, 2, 4),
+        strides=(1, 2, 1, 1),
+        norm_cfg=norm_cfg,
+        norm_eval=False,
+        style="pytorch",
+        contract_dilation=True,
+    ),
+    decode_head=dict(
+        type="DNLHead",
+        in_channels=2048,
+        in_index=3,
+        channels=512,
+        dropout_ratio=0.1,
+        reduction=2,
+        use_scale=True,
+        mode="embedded_gaussian",
+        num_classes=19,
+        norm_cfg=norm_cfg,
+        align_corners=False,
+        loss_decode=dict(type="CrossEntropyLoss", use_sigmoid=False, loss_weight=1.0),
+    ),
+    auxiliary_head=dict(
+        type="FCNHead",
+        in_channels=1024,
+        in_index=2,
+        channels=256,
+        num_convs=1,
+        concat_input=False,
+        dropout_ratio=0.1,
+        num_classes=19,
+        norm_cfg=norm_cfg,
+        align_corners=False,
+        loss_decode=dict(type="CrossEntropyLoss", use_sigmoid=False, loss_weight=0.4),
+    ),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode="whole"),
+)

--- a/models/configs/resnet50/dnl_r50-d8_512x1024_80k_sem_seg_bdd100k.py
+++ b/models/configs/resnet50/dnl_r50-d8_512x1024_80k_sem_seg_bdd100k.py
@@ -1,0 +1,6 @@
+"""DNL with ResNet-50-d8."""
+
+_base_ = [
+    "./dnl_r50-d8.py",
+]
+load_from = "https://dl.cv.ethz.ch/bdd100k/sem_seg/models/dnl_r50-d8_512x1024_80k_sem_seg_bdd100k.pth"

--- a/models/modules/semantic_networks/resnet_50.py
+++ b/models/modules/semantic_networks/resnet_50.py
@@ -1,0 +1,30 @@
+import os
+from torch import nn
+
+
+class Resnet50Segmentor(nn.Module):
+    def __init__(
+        self,
+        jg_dir,
+        f_s_config,
+        img_size,
+        num_classes=10,
+        final_conv=False,
+        padding_type="zeros",
+    ):
+        super().__init__()
+        import mmcv
+
+        cfg = mmcv.Config.fromfile(os.path.join(jg_dir, f_s_config))
+
+        cfg.model.pretrained = None
+        cfg.model.train_cfg = None
+        # cfg.model.decode_head.num_classes = num_classes
+        from mmseg.models import build_segmentor
+
+        self.resnet50 = build_segmentor(
+            cfg.model, train_cfg=None, test_cfg=cfg.get("test_cfg")
+        )
+
+    def forward(self, x):
+        return self.resnet50.forward_dummy(x)

--- a/models/modules/semantic_networks/resnet_50.py
+++ b/models/modules/semantic_networks/resnet_50.py
@@ -60,7 +60,6 @@ def convert_batchnorm(module):
 
     """
     module_output = module
-    print(type(module))
     if isinstance(module, torch.nn.modules.batchnorm.SyncBatchNorm):
         module_output = torch.nn.BatchNorm2d(
             module.num_features,

--- a/models/modules/semantic_networks/resnet_50.py
+++ b/models/modules/semantic_networks/resnet_50.py
@@ -1,5 +1,6 @@
 import os
 from torch import nn
+import torch
 
 
 class Resnet50Segmentor(nn.Module):
@@ -28,3 +29,54 @@ class Resnet50Segmentor(nn.Module):
 
     def forward(self, x):
         return self.resnet50.forward_dummy(x)
+
+
+def convert_batchnorm(module):
+    r"""Helper function to convert all :attr:`BatchNorm*D` layers in the model to
+    :class:`torch.nn.SyncBatchNorm` layers.
+
+    Args:
+        module (nn.Module): module containing one or more attr:`BatchNorm*D` layers
+        process_group (optional): process group to scope synchronization,
+            default is the whole world
+
+    Returns:
+        The original :attr:`module` with the converted :class:`torch.nn.SyncBatchNorm`
+        layers. If the original :attr:`module` is a :attr:`BatchNorm*D` layer,
+        a new :class:`torch.nn.SyncBatchNorm` layer object will be returned
+        instead.
+
+    Example::
+
+        >>> # Network with nn.BatchNorm layer
+        >>> module = torch.nn.Sequential(
+        >>>            torch.nn.Linear(20, 100),
+        >>>            torch.nn.BatchNorm1d(100),
+        >>>          ).cuda()
+        >>> # creating process group (optional)
+        >>> # process_ids is a list of int identifying rank ids.
+        >>> process_group = torch.distributed.new_group(process_ids)
+        >>> sync_bn_module = torch.nn.SyncBatchNorm.convert_sync_batchnorm(module, process_group)
+
+    """
+    module_output = module
+    print(type(module))
+    if isinstance(module, torch.nn.modules.batchnorm.SyncBatchNorm):
+        module_output = torch.nn.BatchNorm2d(
+            module.num_features,
+            module.eps,
+            module.momentum,
+            module.affine,
+            module.track_running_stats,
+        )
+        if module.affine:
+            with torch.no_grad():
+                module_output.weight = module.weight
+                module_output.bias = module.bias
+        module_output.running_mean = module.running_mean
+        module_output.running_var = module.running_var
+        module_output.num_batches_tracked = module.num_batches_tracked
+    for name, child in module.named_children():
+        module_output.add_module(name, convert_batchnorm(child))
+    del module
+    return module_output

--- a/models/modules/utils.py
+++ b/models/modules/utils.py
@@ -202,7 +202,7 @@ def normal_init(m, mean, std):
         m.bias.data.zero_()
 
 
-segformer_weights = {
+weights = {
     "segformer_mit-b0.pth": "https://download.openmmlab.com/mmsegmentation/v0.5/segformer/segformer_mit-b0_512x512_160k_ade20k/segformer_mit-b0_512x512_160k_ade20k_20210726_101530-8ffa8fda.pth",
     "segformer_mit-b1.pth": "https://download.openmmlab.com/mmsegmentation/v0.5/segformer/segformer_mit-b1_512x512_160k_ade20k/segformer_mit-b1_512x512_160k_ade20k_20210726_112106-d70e859d.pth",
     "segformer_mit-b2.pth": "https://download.openmmlab.com/mmsegmentation/v0.5/segformer/segformer_mit-b2_512x512_160k_ade20k/segformer_mit-b2_512x512_160k_ade20k_20210726_112103-cbd414ac.pth",
@@ -210,18 +210,19 @@ segformer_weights = {
     "segformer_mit-b4.pth": "https://download.openmmlab.com/mmsegmentation/v0.5/segformer/segformer_mit-b4_512x512_160k_ade20k/segformer_mit-b4_512x512_160k_ade20k_20210728_183055-7f509d7d.pth",
     "segformer_mit-b5.pth": "https://download.openmmlab.com/mmsegmentation/v0.5/segformer/segformer_mit-b5_512x512_160k_ade20k/segformer_mit-b5_512x512_160k_ade20k_20210726_145235-94cedf59.pth",
     "segformer_mit-b5_640.pth": "https://download.openmmlab.com/mmsegmentation/v0.5/segformer/segformer_mit-b5_640x640_160k_ade20k/segformer_mit-b5_640x640_160k_ade20k_20210801_121243-41d2845b.pth",
+    "dnl_r50-d8_512x1024_80k_sem_seg_bdd100k.pth": "https://dl.cv.ethz.ch/bdd100k/sem_seg/models/dnl_r50-d8_512x1024_80k_sem_seg_bdd100k.pth",
 }
 
 
-def download_segformer_weight(path):
+def download_weight(path):
     for i in range(2, len(path.split("/"))):
         temp = path.split("/")[:i]
         cur_path = "/".join(temp)
         if not os.path.isdir(cur_path):
             os.mkdir(cur_path)
     model_name = path.split("/")[-1]
-    if model_name in segformer_weights:
-        wget.download(segformer_weights[model_name], path)
+    if model_name in weights:
+        wget.download(weights[model_name], path)
     else:
         raise NameError(
             "There is no pretrained weight to download for %s, you need to provide a path to segformer weights."

--- a/models/networks.py
+++ b/models/networks.py
@@ -40,7 +40,8 @@ from .modules.projected_d.discriminator import (
 )
 from .modules.segformer.segformer_generator import Segformer, SegformerGenerator_attn
 
-from .modules.semantic_networks.resnet_50 import Resnet50Segmentor
+
+from .modules.semantic_networks.resnet_50 import Resnet50Segmentor, convert_batchnorm
 
 
 class BaseNetwork(nn.Module):
@@ -496,6 +497,7 @@ def define_f(
         weights = get_weights(weight_path)
         net.resnet50.load_state_dict(weights["state_dict"], strict=True)
         del net.resnet50.auxiliary_head
+        convert_batchnorm(net)
         return net
 
     return init_net(net, model_init_type, model_init_gain)

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -330,8 +330,8 @@ class BaseOptions:
             "--f_s_net",
             type=str,
             default="vgg",
-            choices=["vgg", "unet", "segformer"],
-            help="specify f_s network [vgg|unet|segformer]",
+            choices=["vgg", "unet", "segformer", "resnet50"],
+            help="specify f_s network",
         )
         parser.add_argument(
             "--f_s_dropout",
@@ -362,13 +362,13 @@ class BaseOptions:
             help="# of filters in the first conv layer of classifier",
         )
         parser.add_argument(
-            "--f_s_config_segformer",
+            "--f_s_config",
             type=str,
             default="models/configs/segformer/segformer_config_b0.py",
             help="path to segformer configuration file for f_s",
         )
         parser.add_argument(
-            "--f_s_weight_segformer",
+            "--f_s_weight",
             type=str,
             default="models/configs/segformer/pretrain/segformer_mit-b0.pth",
             help="path to segformer weight for f_s",


### PR DESCRIPTION
Allow to use a pretrained resnet50 on BDD100k dataset from https://github.com/SysCV/bdd100k-models/tree/main/sem_seg

Usage : 
```
pytohn train.py --f_s_config models/configs/resnet50/dnl_r50-d8_512x1024_80k_sem_seg_bdd100k.py --f_s_weight models/configs/resnet50/pretrain/dnl_r50-d8_512x1024_80k_sem_seg_bdd100k.pth  --f_s_net resnet50

```