### PR TITLE
feat(ml): mask generation across domains for GAN semantics

### DIFF
--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -353,8 +353,11 @@ class CUTModel(BaseGanModel):
             losses_G += ["G_z"]
 
         for discriminator in self.discriminators:
-            losses_G.append(discriminator.loss_name_G)
             losses_D.append(discriminator.loss_name_D)
+            if "mask" in discriminator.name:
+                continue
+            else:
+                losses_G.append(discriminator.loss_name_G)
 
         self.loss_names_G += losses_G
         self.loss_names_D += losses_D
@@ -444,6 +447,9 @@ class CUTModel(BaseGanModel):
         if self.opt.train_sem_idt:
             visual_names_seg_B += ["pfB_idt_max"]
 
+        if "mask" in self.opt.D_netDs:
+            visual_names_seg_B += ["real_mask_B_inv", "fake_mask_B_inv"]
+
         self.visual_names += [visual_names_seg_A, visual_names_seg_B]
 
         if self.opt.train_mask_out_mask and self.isTrain:
@@ -491,6 +497,9 @@ class CUTModel(BaseGanModel):
 
         if self.use_depth:
             self.compute_fake_real_with_depth(fake_name="fake_B", real_name="real_B")
+
+        if "mask" in self.opt.D_netDs:
+            self.compute_fake_real_masks()
 
         if self.opt.alg_cut_nce_idt:
             self.idt_B = self.fake[self.real_A.size(0) :]

--- a/models/gan_networks.py
+++ b/models/gan_networks.py
@@ -261,6 +261,7 @@ def define_D(
     data_online_context_pixels,
     D_vision_aided_backbones,
     dataaug_D_diffusion,
+    f_s_semantic_nclasses,
     **unused_options
 ):
 
@@ -408,6 +409,17 @@ def define_D(
             )
 
             return_nets[netD] = net  # no init since custom frozen backbone
+
+        elif netD == "mask":
+            net = NLayerDiscriminator(
+                f_s_semantic_nclasses,  # as number of input dimension, i.e. one-hot from gumbel-softmax
+                D_ndf,
+                n_layers=3,
+                norm_layer=norm_layer,
+                use_dropout=D_dropout,
+                use_spectral=D_spectral,
+            )
+            return_nets[netD] = init_net(net, model_init_type, model_init_gain)
 
         else:
             raise NotImplementedError(

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -369,6 +369,7 @@ class BaseOptions:
                 "temporal",
                 "vision_aided",
                 "depth",
+                "mask",
             ]
             + list(TORCH_MODEL_CLASSES.keys()),
             help="specify discriminator architecture, D_n_layers allows you to specify the layers in the discriminator. NB: duplicated arguments will be ignored.",


### PR DESCRIPTION
This PR adds mask automated generation from A to B. `f_s` is dually trained from a mask discriminator and from domain B masks when available. That is, the semantic pixel location is learned, as opposed to be specified as input.

- Added option: new `"mask"` discriminator

- Training run example
```
python3 train.py --dataroot /path/to/dataset --checkpoints_dir /path/to/checkpoints/ --name test_maskgen --output_display_freq 100 --output_print_freq 100 --gpu 0 --train_G_lr 0.0002 --train_D_lr 0.0001 --data_crop_size 256 --data_load_size 256 --data_dataset_mode unaligned_labeled_mask_online --model_type cut --train_semantic_mask --train_batch_size 1 --train_iter_size 5 --model_input_nc 3 --model_output_nc 3 --f_s_net unet --train_mask_out_mask --f_s_semantic_nclasses 3 --G_netG mobile_resnet_attn --data_online_creation_crop_size_A 512 --data_online_creation_crop_size_B 512 --dataaug_D_noise 0.01 --alg_cut_nce_idt --train_sem_use_label_B --D_netDs projected_d basic depth mask --D_proj_interp 256 --D_proj_network_type efficientnet --train_G_ema  --train_optim radam --data_relative_paths --train_mask_no_train_f_s_A --train_mask_f_s_B
```