### PR TITLE
feat: metrics for testset

### DIFF
--- a/data/__init__.py
+++ b/data/__init__.py
@@ -47,26 +47,26 @@ def get_option_setter(dataset_name):
     return dataset_class.modify_commandline_options
 
 
-def create_dataset(opt):
+def create_dataset(opt, phase):
     dataset_class = find_dataset_using_name(opt.data_dataset_mode)
-    dataset = dataset_class(opt)
+    dataset = dataset_class(opt, phase)
     return dataset
 
 
-def create_dataloader(opt, rank, dataset):
-    data_loader = CustomDatasetDataLoader(opt, rank, dataset)
+def create_dataloader(opt, rank, dataset, batch_size):
+    data_loader = CustomDatasetDataLoader(opt, rank, dataset, batch_size)
     dataset = data_loader.load_data()
     return dataset
 
 
-def create_dataset_temporal(opt):
+def create_dataset_temporal(opt, phase):
     dataset_class = find_dataset_using_name("temporal")
-    dataset = dataset_class(opt)
+    dataset = dataset_class(opt, phase)
     return dataset
 
 
-def create_iterable_dataloader(opt, rank, dataset):
-    data_loader = IterableCustomDatasetDataLoader(opt, rank, dataset)
+def create_iterable_dataloader(opt, rank, dataset, batch_size):
+    data_loader = IterableCustomDatasetDataLoader(opt, rank, dataset, batch_size)
     dataset = data_loader.load_data()
     return dataset
 
@@ -82,7 +82,7 @@ def collate_fn(batch):
 class CustomDatasetDataLoader:
     """Wrapper class of Dataset class that performs multi-threaded data loading"""
 
-    def __init__(self, opt, rank, dataset):
+    def __init__(self, opt, rank, dataset, batch_size):
         """Initialize this class
 
         Step 1: create a dataset instance given the name [dataset_mode]
@@ -106,7 +106,7 @@ class CustomDatasetDataLoader:
             shuffle = not opt.data_serial_batches
         self.dataloader = torch.utils.data.DataLoader(
             self.dataset,
-            batch_size=opt.train_batch_size,
+            batch_size=batch_size,
             sampler=sampler,
             shuffle=shuffle,
             num_workers=int(opt.data_num_threads),
@@ -133,7 +133,7 @@ class CustomDatasetDataLoader:
 class IterableCustomDatasetDataLoader:
     """Wrapper class of Dataset class that performs multi-threaded data loading"""
 
-    def __init__(self, opt, rank, dataset):
+    def __init__(self, opt, rank, dataset, batch_size):
         """Initialize this class
 
         Step 1: create a dataset instance given the name [dataset_mode]
@@ -147,7 +147,7 @@ class IterableCustomDatasetDataLoader:
         shuffle = not opt.data_serial_batches
         self.dataloader = torch.utils.data.DataLoader(
             self.dataset,
-            batch_size=opt.train_batch_size,
+            batch_size=batch_size,
             sampler=sampler,
             num_workers=int(opt.data_num_threads),
             collate_fn=collate_fn,

--- a/data/base_dataset.py
+++ b/data/base_dataset.py
@@ -37,12 +37,15 @@ class BaseDataset(data.Dataset, ABC):
     -- <modify_commandline_options>:    (optionally) add dataset-specific options and set default options.
     """
 
-    def __init__(self, opt):
+    def __init__(self, opt, phase):
         """Initialize the class; save the options in the class
 
         Parameters:
             opt (Option class)-- stores all the experiment flags; needs to be a subclass of BaseOptions
+            phase (str)       -- can be train,test or validation.
         """
+        self.phase = phase
+        print("self.phase", self.phase)
         self.opt = opt
 
         self.use_domain_B = not "self_supervised" in self.opt.data_dataset_mode
@@ -156,22 +159,22 @@ class BaseDataset(data.Dataset, ABC):
 
         if not btoA:
             self.dir_A = os.path.join(
-                self.opt.dataroot, self.opt.phase + "A"
+                self.opt.dataroot, self.phase + "A"
             )  # create a path '/path/to/data/trainA'
 
             if self.use_domain_B:
 
                 self.dir_B = os.path.join(
-                    self.opt.dataroot, self.opt.phase + "B"
+                    self.opt.dataroot, self.phase + "B"
                 )  # create a path '/path/to/data/trainB'
         else:
             self.dir_A = os.path.join(
-                self.opt.dataroot, self.opt.phase + "B"
+                self.opt.dataroot, self.phase + "B"
             )  # create a path '/path/to/data/trainB'
 
             if self.use_domain_B:
                 self.dir_B = os.path.join(
-                    self.opt.dataroot, self.opt.phase + "A"
+                    self.opt.dataroot, self.phase + "A"
                 )  # create a path '/path/to/data/trainA'
 
     def get_validation_set(self, size):

--- a/data/self_supervised_labeled_mask_dataset.py
+++ b/data/self_supervised_labeled_mask_dataset.py
@@ -12,13 +12,13 @@ class SelfSupervisedLabeledMaskDataset(UnalignedLabeledMaskDataset):
     This dataset class can create paired datasets with mask labels from only one domain.
     """
 
-    def __init__(self, opt):
+    def __init__(self, opt, phase):
         """Initialize this dataset class.
 
         Parameters:
             opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
         """
-        super().__init__(opt)
+        super().__init__(opt, phase)
 
     def get_img(
         self,

--- a/data/self_supervised_labeled_mask_online_dataset.py
+++ b/data/self_supervised_labeled_mask_online_dataset.py
@@ -12,13 +12,13 @@ class SelfSupervisedLabeledMaskOnlineDataset(UnalignedLabeledMaskOnlineDataset):
     This dataset class can create datasets with mask labels from one domain.
     """
 
-    def __init__(self, opt):
+    def __init__(self, opt, phase):
         """Initialize this dataset class.
 
         Parameters:
             opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
         """
-        super().__init__(opt)
+        super().__init__(opt, phase)
 
     def get_img(
         self,

--- a/data/self_supervised_temporal_dataset.py
+++ b/data/self_supervised_temporal_dataset.py
@@ -10,13 +10,13 @@ class SelfSupervisedTemporalDataset(TemporalDataset):
     This dataset class can create datasets with mask labels from one domain.
     """
 
-    def __init__(self, opt):
+    def __init__(self, opt, phase):
         """Initialize this dataset class.
 
         Parameters:
             opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
         """
-        super().__init__(opt)
+        super().__init__(opt, phase)
 
     def get_img(
         self,

--- a/data/temporal_dataset.py
+++ b/data/temporal_dataset.py
@@ -27,8 +27,8 @@ class TemporalDataset(BaseDataset):
         else:
             return self.A_size
 
-    def __init__(self, opt):
-        BaseDataset.__init__(self, opt)
+    def __init__(self, opt, phase):
+        BaseDataset.__init__(self, opt, phase)
         super(TemporalDataset).__init__()
 
         self.A_img_paths, self.A_label_mask_paths = make_labeled_path_dataset(

--- a/data/unaligned_dataset.py
+++ b/data/unaligned_dataset.py
@@ -16,20 +16,13 @@ class UnalignedDataset(BaseDataset):
     '/path/to/data/testA' and '/path/to/data/testB' during test time.
     """
 
-    def __init__(self, opt):
+    def __init__(self, opt, phase):
         """Initialize this dataset class.
 
         Parameters:
             opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
         """
-        BaseDataset.__init__(self, opt)
-
-        self.dir_A_val = os.path.join(
-            opt.dataroot, "validationA"
-        )  # create a path '/path/to/data/validationA'
-        self.dir_B_val = os.path.join(
-            opt.dataroot, "validationB"
-        )  # create a path '/path/to/data/validationB'
+        BaseDataset.__init__(self, opt, phase)
 
         self.A_img_paths = sorted(
             make_dataset(self.dir_A, opt.data_max_dataset_size)
@@ -37,16 +30,6 @@ class UnalignedDataset(BaseDataset):
         self.B_img_paths = sorted(
             make_dataset(self.dir_B, opt.data_max_dataset_size)
         )  # load images from '/path/to/data/trainB'
-
-        if os.path.exists(self.dir_A_val):
-            self.A_img_paths_val = sorted(
-                make_dataset(self.dir_A_val, opt.data_max_dataset_size)
-            )
-
-        if os.path.exists(self.dir_B_val):
-            self.B_img_paths_val = sorted(
-                make_dataset(self.dir_B_val, opt.data_max_dataset_size)
-            )
 
         self.A_size = len(self.A_img_paths)  # get the size of dataset A
         self.B_size = len(self.B_img_paths)  # get the size of dataset B

--- a/data/unaligned_labeled_cls_dataset.py
+++ b/data/unaligned_labeled_cls_dataset.py
@@ -27,13 +27,13 @@ class UnalignedLabeledClsDataset(BaseDataset):
     '/path/to/data/testA' and '/path/to/data/testB' during test time.
     """
 
-    def __init__(self, opt):
+    def __init__(self, opt, phase):
         """Initialize this dataset class.
 
         Parameters:
             opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
         """
-        BaseDataset.__init__(self, opt)
+        BaseDataset.__init__(self, opt, phase)
 
         if not os.path.isfile(self.dir_A + "/paths.txt"):
             self.A_img_paths, self.A_label = make_labeled_dataset(

--- a/data/unaligned_labeled_mask_cls_dataset.py
+++ b/data/unaligned_labeled_mask_cls_dataset.py
@@ -3,13 +3,13 @@ import torch
 
 
 class UnalignedLabeledMaskClsDataset(UnalignedLabeledMaskDataset):
-    def __init__(self, opt):
+    def __init__(self, opt, phase):
         """Initialize this dataset class.
 
         Parameters:
             opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
         """
-        UnalignedLabeledMaskDataset.__init__(self, opt)
+        UnalignedLabeledMaskDataset.__init__(self, opt, phase)
 
         self.A_label_cls = []
         self.B_label_cls = []

--- a/data/unaligned_labeled_mask_cls_online_dataset.py
+++ b/data/unaligned_labeled_mask_cls_online_dataset.py
@@ -2,13 +2,13 @@ from data.unaligned_labeled_mask_online_dataset import UnalignedLabeledMaskOnlin
 
 
 class UnalignedLabeledMaskClsOnlineDataset(UnalignedLabeledMaskOnlineDataset):
-    def __init__(self, opt):
+    def __init__(self, opt, phase):
         """Initialize this dataset class.
 
         Parameters:
             opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
         """
-        UnalignedLabeledMaskOnlineDataset.__init__(self, opt)
+        UnalignedLabeledMaskOnlineDataset.__init__(self, opt, phase)
         self.header = ["img", "cls", "mask"]
 
     def get_img(

--- a/data/unaligned_labeled_mask_dataset.py
+++ b/data/unaligned_labeled_mask_dataset.py
@@ -24,13 +24,13 @@ class UnalignedLabeledMaskDataset(BaseDataset):
     '/path/to/data/testA' and '/path/to/data/testB' during test time.
     """
 
-    def __init__(self, opt):
+    def __init__(self, opt, phase):
         """Initialize this dataset class.
 
         Parameters:
             opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
         """
-        BaseDataset.__init__(self, opt)
+        BaseDataset.__init__(self, opt, phase)
 
         if os.path.exists(self.dir_A):
             self.A_img_paths, self.A_label = make_labeled_path_dataset(

--- a/models/cycle_gan_model.py
+++ b/models/cycle_gan_model.py
@@ -267,6 +267,9 @@ class CycleGanModel(BaseGanModel):
             visual_names_out_mask_B = ["real_B_out_mask", "fake_A_out_mask"]
             self.visual_names += [visual_names_out_mask_A, visual_names_out_mask_B]
 
+    def inference(self):
+        self.fake_B = self.netG_A(self.real_A)  # G_A(A)
+
     def forward_cycle_gan(self):
         """Run forward pass; called by both functions <optimize_parameters> and <test>."""
 

--- a/options/train_options.py
+++ b/options/train_options.py
@@ -151,6 +151,11 @@ class TrainOptions(BaseOptions):
         parser.add_argument(
             "--train_batch_size", type=int, default=1, help="input batch size"
         )
+
+        parser.add_argument(
+            "--test_batch_size", type=int, default=1, help="input batch size"
+        )
+
         parser.add_argument(
             "--train_epoch",
             type=str,
@@ -170,7 +175,7 @@ class TrainOptions(BaseOptions):
             help="which iteration to load? if load_iter > 0, the code will load models by iter_[load_iter]; otherwise, the code will load models by [epoch]",
         )
         parser.add_argument("--train_compute_metrics", action="store_true")
-        parser.add_argument("--train_compute_metrics_val", action="store_true")
+        parser.add_argument("--train_compute_metrics_test", action="store_true")
         parser.add_argument("--train_metrics_every", type=int, default=1000)
         parser.add_argument(
             "--train_G_ema",

--- a/train.py
+++ b/train.py
@@ -24,6 +24,7 @@ import os
 import signal
 import time
 import warnings
+import copy
 
 import torch
 import torch.distributed as dist
@@ -90,18 +91,22 @@ def train_gpu(rank, world_size, opt, trainset, trainset_temporal):
 
     if rank == 0:
         if opt.train_compute_metrics_test:
-            testset = create_dataset(opt, phase="test")
+
+            temp_opt = copy.deepcopy(opt)
+            temp_opt.gpu_ids = temp_opt.gpu_ids[:1]
+
+            testset = create_dataset(temp_opt, phase="test")
             print("The number of testing images = %d" % len(testset))
 
             dataloader_test = create_dataloader(
-                opt, rank, testset, batch_size=opt.test_batch_size
+                temp_opt, rank, testset, batch_size=opt.test_batch_size
             )  # create a dataset given opt.dataset_mode and other options
 
             if use_temporal:
-                testset_temporal = create_dataset_temporal(opt, phase="test")
+                testset_temporal = create_dataset_temporal(temp_opt, phase="test")
 
                 dataloader_test_temporal = create_iterable_dataloader(
-                    opt, rank, testset_temporal, batch_size=opt.test_batch_size
+                    temp_opt, rank, testset_temporal, batch_size=opt.test_batch_size
                 )
             else:
                 dataloader_test_temporal = None

--- a/util/metrics.py
+++ b/util/metrics.py
@@ -90,7 +90,7 @@ def get_activations(
         )
         batch_size = len(dataloader)
 
-    pred_arr = np.empty((len(dataloader), dims))
+    pred_arr = torch.empty((len(dataloader), dims))
 
     start_idx = 0
 
@@ -98,11 +98,9 @@ def get_activations(
         if isinstance(dataloader, list):
             dataloader = dataloader[:nb_max_img]
         else:
-            index = random.sample(np.range(nb_max_img))
-            subset = torch.utils.data.Subset(dataloader, index)
-            dataloader = subset
-
-    # print("batchsize", batch_size)
+            print(
+                "Number of images limitation doesn't work with pytorch dataloaders, the full dataset will be used instead for activations computation."
+            )
 
     for batch in tqdm(dataloader, total=len(dataloader) // batch_size):
         if isinstance(batch, dict) and domain is not None:
@@ -130,115 +128,13 @@ def get_activations(
 
             pred = pred.squeeze(3).squeeze(2)
 
-        pred = pred.cpu().numpy()
+        pred = pred.cpu()
 
         pred_arr[start_idx : start_idx + pred.shape[0]] = pred
 
         start_idx = start_idx + pred.shape[0]
 
     return pred_arr
-
-
-def calculate_frechet_distance(mu1, sigma1, mu2, sigma2, eps=1e-6):
-    """Numpy implementation of the Frechet Distance.
-    The Frechet distance between two multivariate Gaussians X_1 ~ N(mu_1, C_1)
-    and X_2 ~ N(mu_2, C_2) is
-            d^2 = ||mu_1 - mu_2||^2 + Tr(C_1 + C_2 - 2*sqrt(C_1*C_2)).
-
-    Stable version by Dougal J. Sutherland.
-
-    Params:
-    -- mu1   : Numpy array containing the activations of a layer of the
-               inception net (like returned by the function 'get_predictions')
-               for generated samples.
-    -- mu2   : The sample mean over activations, precalculated on an
-               representative data set.
-    -- sigma1: The covariance matrix over activations for generated samples.
-    -- sigma2: The covariance matrix over activations, precalculated on an
-               representative data set.
-
-    Returns:
-    --   : The Frechet Distance.
-    """
-
-    mu1 = np.atleast_1d(mu1)
-    mu2 = np.atleast_1d(mu2)
-
-    sigma1 = np.atleast_2d(sigma1)
-    sigma2 = np.atleast_2d(sigma2)
-
-    assert (
-        mu1.shape == mu2.shape
-    ), "Training and test mean vectors have different lengths"
-    assert (
-        sigma1.shape == sigma2.shape
-    ), "Training and test covariances have different dimensions"
-
-    diff = mu1 - mu2
-
-    # Product might be almost singular
-    covmean, _ = linalg.sqrtm(sigma1.dot(sigma2), disp=False)
-    if not np.isfinite(covmean).all():
-        msg = (
-            "fid calculation produces singular product; "
-            "adding %s to diagonal of cov estimates"
-        ) % eps
-        print(msg)
-        offset = np.eye(sigma1.shape[0]) * eps
-        covmean = linalg.sqrtm((sigma1 + offset).dot(sigma2 + offset))
-
-    # Numerical error might give slight imaginary component
-    if np.iscomplexobj(covmean):
-        if not np.allclose(np.diagonal(covmean).imag, 0, atol=1e-3):
-            m = np.max(np.abs(covmean.imag))
-            raise ValueError("Imaginary component {}".format(m))
-        covmean = covmean.real
-
-    tr_covmean = np.trace(covmean)
-
-    return diff.dot(diff) + np.trace(sigma1) + np.trace(sigma2) - 2 * tr_covmean
-
-
-def calculate_activation_statistics(
-    dataloader,
-    model,
-    domain,
-    batch_size,
-    dims,
-    device,
-    nb_max_img,
-):
-    """Calculation of the statistics used by the FID.
-    Params:
-    -- dataloader  : JG-like dataloader (it can be a list of tensors too)
-    -- model       : Instance of inception model
-    -- domain      : image domain
-    -- batch_size  : The images numpy array is split into batches with
-                     batch size batch_size. A reasonable batch size
-                     depends on the hardware.
-    -- dims        : Dimensionality of features returned by Inception
-    -- device      : Device to run calculations
-
-    Returns:
-    -- mu    : The mean over samples of the activations of the pool_3 layer of
-               the inception model.
-    -- sigma : The covariance matrix of the activations of the pool_3 layer of
-               the inception model.
-    """
-
-    act = get_activations(
-        dataloader=dataloader,
-        model=model,
-        domain=domain,
-        batch_size=batch_size,
-        dims=dims,
-        device=device,
-        nb_max_img=nb_max_img,
-    )
-
-    mu = np.mean(act, axis=0)
-    sigma = np.cov(act, rowvar=False)
-    return mu, sigma, act
 
 
 def _compute_statistics_of_dataloader(
@@ -254,12 +150,11 @@ def _compute_statistics_of_dataloader(
 ):
 
     if path_sv is not None and os.path.isfile(path_sv):
-        print("Mu and sigma loaded for domain {domain}, from %s." % path_sv)
-        f = np.load(path_sv)
-        m, s, a = f["mu"][:], f["sigma"][:], f["activation"][:]
-        f.close()
+        print("Activations loaded for domain {domain}, from %s." % path_sv)
+        f = torch.load(path_sv)
+        a = f["activation"][:]
     else:
-        m, s, a = calculate_activation_statistics(
+        a = get_activations(
             dataloader=dataloader,
             model=model,
             domain=domain,
@@ -270,11 +165,6 @@ def _compute_statistics_of_dataloader(
         )
 
     if path_sv:
-        np.savez(
-            path_sv,
-            mu=m,
-            sigma=s,
-            activation=a,
-        )
+        torch.save({"activation": a}, path_sv)
 
-    return m, s, a
+    return a


### PR DESCRIPTION
We can now compute FID, MSID and KID on a testset. Each `train_metrics_every`, we will compute fake images over all the testset and then compute metrics.

Note : The dataset needs to have `trainA` and `trainB` directories as usual **but also** `testA` and `testB` directories. 

Usage 

```
python3 train.py --train_compute_metrics_test --train_metrics_every 10000
```