### PR TITLE
feat: set mininum context via crop/bbox ratio

### DIFF
--- a/data/online_creation.py
+++ b/data/online_creation.py
@@ -30,6 +30,7 @@ def crop_image(
     inverted_mask=False,
     single_bbox=False,
     override_class=-1,
+    min_crop_bbox_ratio=None,
 ):
 
     margin = context_pixels * 2
@@ -222,6 +223,13 @@ def crop_image(
 
         if crop_size_max < crop_size_min:
             raise ValueError(f"Crop size cannot be computed for {img_path}")
+
+        if min_crop_bbox_ratio:
+            expected_crop_size = round(max(height, width) * min_crop_bbox_ratio)
+            if crop_size_max < expected_crop_size:
+                warnings.warn(f"Enlarging crop to match min_crop_bbox_ratio")
+                crop_size_min = expected_crop_size
+                crop_size_max = expected_crop_size
 
         crop_size = random.randint(crop_size_min, crop_size_max)
 

--- a/scripts/gen_single_image_diffusion.py
+++ b/scripts/gen_single_image_diffusion.py
@@ -112,6 +112,7 @@ def generate(
     cls,
     alg_palette_super_resolution_downsample,
     data_refined_mask,
+    min_crop_bbox_ratio,
     **unused_options,
 ):
     # seed
@@ -236,6 +237,7 @@ def generate(
             get_crop_coordinates=True,
             crop_center=True,
             bbox_ref_id=bbox_idx,
+            min_crop_bbox_ratio=min_crop_bbox_ratio,
         )
 
         img, mask, ref_bbox = crop_image(
@@ -603,6 +605,12 @@ if __name__ == "__main__":
         "--data_refined_mask",
         action="store_true",
         help="whether to use refined mask with sam",
+    )
+
+    options.parser.add_argument(
+        "--min_crop_bbox_ratio",
+        type=float,
+        help="minimum crop/bbox ratio, allows to add context when bbox is larger than crop",
     )
 
     args = options.parse()


### PR DESCRIPTION
Adds `--min_crop_bbox_ratio` to ensure inpainting is surrounded by a minimum of pixels.