### PR TITLE
Chore release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "joliGEN",
+    "description": "Generative AI Toolset with GANs and Diffusion for Real-World Applications",
+    "version": "1.0.0",
+    "private": true,
+    "devDependencies": {
+        "standard-version": "^9.0.0"
+    },
+    "standard-version": {
+        "header": "# joliGEN: Generative AI Toolset (Changelog)\n",
+        "script": {
+            "postchangelog": "sed -i -e '/\\*\\*ci:\\*\\*/d' CHANGELOG.md"
+        }
+    }
+}

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+kind=${1:-major}
+git rm CHANGELOG.md
+yarn run standard-version -r $kind
+tag=$(cat package.json | jq -r .version)
+
+sed -ne "/^## \[$tag\]/,/^##.*202/p" CHANGELOG.md | sed -e '$d' -e '1d' > note.md
+
+cat >> note.md <<EOF
+### Docker images:
+
+* joliGEN server: \`docker pull docker.jolibrain.com/joligen_server:v$tag\`
+* All images available from https://docker.jolibrain.com/#!/taglist/joligen_server
+EOF
+
+trap "rm -f note.md" EXIT
+gh release create --title "joliGEN v$tag" -F note.md -d v$tag


### PR DESCRIPTION
To release:
```
yarn
./release.sh
```

Default behavior is to bump the major version.