### PR TITLE
fix: visdom autostart and no display

### DIFF
--- a/options/train_options.py
+++ b/options/train_options.py
@@ -29,14 +29,19 @@ class TrainOptions(BaseOptions):
             type=str,
             default=["visdom"],
             nargs="*",
-            choices=["visdom", "aim"],
-            help="output display, either visdom or aim",
+            choices=["visdom", "aim", "none"],
+            help="output display, either visdom, aim or no output",
         )
         parser.add_argument(
             "--output_display_id",
             type=int,
             default=1,
             help="window id of the web display",
+        )
+        parser.add_argument(
+            "--output_display_visdom_autostart",
+            action="store_true",
+            help="whether to start a visdom server automatically",
         )
         parser.add_argument(
             "--output_display_visdom_server",

--- a/train.py
+++ b/train.py
@@ -225,13 +225,14 @@ def train_gpu(rank, world_size, opt, trainset, trainset_temporal):
                 ):  # display images on visdom and save images to a HTML file
                     save_result = total_iters % opt.output_update_html_freq == 0
                     model.compute_visuals()
-                    visualizer.display_current_results(
-                        model.get_current_visuals(),
-                        epoch,
-                        save_result,
-                        params=model.get_display_param(),
-                        first=(total_iters == batch_size),
-                    )
+                    if not "none" in opt.output_display_type:
+                        visualizer.display_current_results(
+                            model.get_current_visuals(),
+                            epoch,
+                            save_result,
+                            params=model.get_display_param(),
+                            first=(total_iters == batch_size),
+                        )
 
                 if (
                     total_iters % opt.train_save_latest_freq < batch_size

--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -83,7 +83,7 @@ class Visualizer:
                 port=self.opt.output_display_visdom_port,
                 env=opt.output_display_env,
             )
-            if not self.vis.check_connection():
+            if not self.vis.check_connection() and opt.output_display_visdom_autostart:
                 self.create_visdom_connections()
 
         if "aim" in self.display_type:


### PR DESCRIPTION
This PR:
- makes display optional with new choice `--output_display_type none` 
- makes joliGEN start a visdom server automatically only with `--output_display_visdom_autostart` 