### PR TITLE
chore(ci): skip-tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,9 @@ pipeline {
   }
   stages {
     stage('Tests') {
+      when {
+       expression {!env.CHANGE_ID || pullRequest.labels.findAll { it == "ci:skip-tests" }.size() == 0 }
+      }
       steps {
         sh 'printenv | sort'
         sh 'mkdir /home/jenkins/app/checkpoints'


### PR DESCRIPTION
Ability to skip tests from PR, with label `ci:skip-tests`, useful for documentation PRs.