### PR TITLE
chore: remove metrics compute on trainset

### DIFF
--- a/options/train_options.py
+++ b/options/train_options.py
@@ -179,7 +179,6 @@ class TrainOptions(BaseOptions):
             default=0,
             help="which iteration to load? if load_iter > 0, the code will load models by iter_[load_iter]; otherwise, the code will load models by [epoch]",
         )
-        parser.add_argument("--train_compute_metrics", action="store_true")
         parser.add_argument("--train_compute_metrics_test", action="store_true")
         parser.add_argument("--train_metrics_every", type=int, default=1000)
         parser.add_argument(

--- a/train.py
+++ b/train.py
@@ -251,11 +251,9 @@ def train_gpu(rank, world_size, opt, trainset, trainset_temporal):
                         model.export_networks(save_suffix)
 
                 if total_iters % opt.train_metrics_every < batch_size and (
-                    opt.train_compute_metrics or opt.train_compute_metrics_test
+                    opt.train_compute_metrics_test
                 ):
                     with torch.no_grad():
-                        if opt.train_compute_metrics:
-                            model.compute_metrics()
 
                         if opt.train_compute_metrics_test:
                             if use_temporal:


### PR DESCRIPTION
This PR removes the metrics (FID, KID...) computation over trainset. 