### PR TITLE
fix: rst autodoc + ci local testing

### DIFF
--- a/.github/workflows/github-actions-doc-options-update.yml
+++ b/.github/workflows/github-actions-doc-options-update.yml
@@ -14,22 +14,35 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
-      - name : install req
+      - name: install req
         run: |
-            pip install -r ./requirements.txt
-            pip install m2r fastapi uvicorn
-      - name : update
+          pip install -r ./requirements.txt
+          pip install fastapi uvicorn opencv-python-headless
+          sudo wget https://github.com/jgm/pandoc/releases/download/3.1.3/pandoc-3.1.3-1-amd64.deb
+          sudo dpkg -i pandoc-3.1.3-1-amd64.deb
+      - name: update
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
-      - name : run script
+      - name: run script
+        run: python ./scripts/generate_doc.py
+      - name: convert md to rst
         run: |
-          python ./scripts/generate_doc.py
-          m2r docs/options.md; mv docs/options.rst docs/source/options.rst
-      - name : generate api doc
+          cp docs/options.md docs/options_copy.md
+          file="docs/options_copy.md"
+          contents=$(cat "$file")
+
+          double_dash_contents=$(echo "$contents" | sed 's/\([^-\]\)--\([^-\]\)/\1\\--\2/g')
+          new_contents=$(echo "$double_dash_contents" | sed 's/\\|/,/g')
+          echo "$new_contents" > "$file"
+
+          pandoc --from markdown --to rst --standalone --wrap=none -s $file -o docs/source/options.rst
+          rm $file
+      - name: generate api doc
         run: bash ./scripts/generate_api_doc.sh
-      - name : push
-        run : |
+      - name: push
+        if: ${{ !env.ACT }}
+        run: |
           git config user.name github-actions-jg
           git config user.email contact@jolibrain.com
           git add .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,7 +100,7 @@ html_context = {
     "github_host": "github.com",
     "github_user": "jolibrain",  # Username
     "github_repo": "joliGEN",  # Repo name
-    "github_version": "feat_jolidoc",  # Branch
+    "github_version": "master",  # Branch
     "conf_py_path": "/docs/source/",  # Path in the checkout to the docs root
 }
 


### PR DESCRIPTION
# PR contents
- Options.rst tables are now converted from md to rst with pandoc (m2r is deprecated and had a bug), with a bash script to format them well for sphinx
- The "Edit on Github" button on the docs has been redirected to branch master instead of feat_jolidoc

# Test the CI locally using [act](https://github.com/nektos/act#github_token)
1. Install act
2. Generate a github token from your github profile with repos access
3. run `export GITHUB_TOKEN="your_token"`
4. run `act -s GITHUB_TOKEN` 