### PR TITLE
fix: server launching in generate api doc

### DIFF
--- a/scripts/generate_api_doc.sh
+++ b/scripts/generate_api_doc.sh
@@ -10,7 +10,7 @@ mkdir -p ${DOC_PATH}
 uvicorn server.joligen_api:app --host localhost --port ${PORT} &
 pid=$!
 
-sleep 3
+sleep 10
 
 for i in {1..30}
 do


### PR DESCRIPTION
![image](https://github.com/jolibrain/joliGEN/assets/60258164/a3b0dfb2-469b-4221-a4c2-a98d94a20a8f)

Github actions seem to fail because we try to connect JG server before launching it. 