### PR TITLE
feat: MobileSam implementation [2306.14289]

### DIFF
--- a/examples/example_gan_glasses2noglasses.json
+++ b/examples/example_gan_glasses2noglasses.json
@@ -105,10 +105,10 @@
       "load_size_A": [],
       "load_size_B": [],
       "mask_delta_A": [
-        0
+	0
       ],
       "mask_delta_B": [
-        0
+	0
       ],
       "mask_random_offset_A": [
         0.0

--- a/examples/example_gan_mario2sonic.json
+++ b/examples/example_gan_mario2sonic.json
@@ -62,11 +62,11 @@
             "load_size_A": [],
             "load_size_B": [],
             "mask_delta_A": [
-                50
-            ],
+		50
+	    ],
             "mask_delta_B": [
-                15
-            ],
+		15
+	    ],
             "mask_random_offset_A": [
                 0.0
             ],

--- a/models/base_gan_model.py
+++ b/models/base_gan_model.py
@@ -1,29 +1,35 @@
-import os
 import copy
-import torch
-from collections import OrderedDict
+import os
 from abc import abstractmethod
-from . import gan_networks
-from .modules.utils import get_scheduler, predict_depth, download_midas_weight
-from .modules.sam.sam_inference import load_sam_weight, predict_sam
-from torchviz import make_dot
-from .base_model import BaseModel
+from collections import OrderedDict
 
-from util.network_group import NetworkGroup
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torchviz import make_dot
 
 # for FID
 from data.base_dataset import get_transform
-from util.util import save_image, tensor2im
-import numpy as np
 from util.diff_aug import DiffAugment
+from util.discriminator import DiscriminatorInfo
 
 # for D accuracy
 from util.image_pool import ImagePool
-import torch.nn.functional as F
+from util.network_group import NetworkGroup
+from util.util import save_image, tensor2im
+
+from . import gan_networks
+from .base_model import BaseModel
 
 # For D loss computing
 from .modules import loss
-from util.discriminator import DiscriminatorInfo
+from .modules.sam.sam_inference import (
+    init_sam_net,
+    load_mobile_sam_weight,
+    load_sam_weight,
+    predict_sam,
+)
+from .modules.utils import download_midas_weight, get_scheduler, predict_depth
 
 
 class BaseGanModel(BaseModel):
@@ -110,8 +116,8 @@ class BaseGanModel(BaseModel):
 
         if "sam" in opt.D_netDs:
             self.use_sam = True
-            self.netfreeze_sam, self.predictor_sam = load_sam_weight(
-                self.opt.D_weight_sam
+            self.netfreeze_sam, self.predictor_sam = init_sam_net(
+                opt.model_type_sam, self.opt.D_weight_sam, self.device
             )
         else:
             self.use_sam = False
@@ -142,14 +148,12 @@ class BaseGanModel(BaseModel):
             self.loss_functions_G.append("compute_temporal_criterion_loss")
 
     def init_semantic_cls(self, opt):
-
         # specify the training losses you want to print out.
         # The training/test scripts will call <BaseModel.get_current_losses>
 
         super().init_semantic_cls(opt)
 
     def init_semantic_mask(self, opt):
-
         # specify the training losses you want to print out.
         # The training/test scripts will call <BaseModel.get_current_losses>
 
@@ -172,7 +176,6 @@ class BaseGanModel(BaseModel):
                 setattr(self, "image_" + str(i), cur_image)
 
         if self.opt.data_online_context_pixels > 0:
-
             bs = self.get_current_batch_size()
             self.mask_context = torch.ones(
                 [
@@ -413,7 +416,6 @@ class BaseGanModel(BaseModel):
             real = getattr(self, real_name)
 
         if hasattr(self, "diff_augment"):
-
             real = self.diff_augment(real)
             fake = self.diff_augment(fake)
 
@@ -544,7 +546,6 @@ class BaseGanModel(BaseModel):
         self.discriminators = []
 
         for discriminator_name in self.discriminators_names:
-
             loss_calculator_name = "D_" + discriminator_name + "_loss_calculator"
 
             if "temporal" in discriminator_name or "projected" in discriminator_name:

--- a/models/modules/sam/sam_inference.py
+++ b/models/modules/sam/sam_inference.py
@@ -1,12 +1,19 @@
 import os
 import random
 import sys
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import cv2
 import numpy as np
 import scipy
 import torch
+from mobile_sam.modeling import (
+    ImageEncoderViT,
+    MaskDecoder,
+    PromptEncoder,
+    TinyViT,
+    TwoWayTransformer,
+)
 from numpy.random import PCG64, Generator
 from segment_anything import SamAutomaticMaskGenerator, SamPredictor, sam_model_registry
 from segment_anything.modeling.image_encoder import ImageEncoderViT
@@ -16,6 +23,7 @@ from segment_anything.utils.transforms import ResizeLongestSide
 from torch import nn
 from torch.nn import functional as F
 
+from models.modules.utils import download_mobile_sam_weight, download_sam_weight
 from util.util import tensor2im
 
 
@@ -443,6 +451,228 @@ class SamPredictorG:
         self.input_w = None
 
 
+class MobileSam(nn.Module):
+    """
+    The MobileSAM related code has been adapted to our needs from the official
+    MobileSAM repository (https://github.com/ChaoningZhang/MobileSAM). Many thanks to
+    their team for this great work!
+    """
+
+    mask_threshold: float = 0.0
+    image_format: str = "RGB"
+
+    def __init__(
+        self,
+        image_encoder: Union[ImageEncoderViT, TinyViT],
+        prompt_encoder: PromptEncoder,
+        mask_decoder: MaskDecoder,
+        pixel_mean: List[float] = [123.675, 116.28, 103.53],
+        pixel_std: List[float] = [58.395, 57.12, 57.375],
+    ) -> None:
+        """
+        SAM predicts object masks from an image and input prompts.
+
+        Arguments:
+          image_encoder (ImageEncoderViT): The backbone used to encode the
+            image into image embeddings that allow for efficient mask prediction.
+          prompt_encoder (PromptEncoder): Encodes various types of input prompts.
+          mask_decoder (MaskDecoder): Predicts masks from the image embeddings
+            and encoded prompts.
+          pixel_mean (list(float)): Mean values for normalizing pixels in the input image.
+          pixel_std (list(float)): Std values for normalizing pixels in the input image.
+        """
+        super().__init__()
+        self.image_encoder = image_encoder
+        self.prompt_encoder = prompt_encoder
+        self.mask_decoder = mask_decoder
+        self.register_buffer(
+            "pixel_mean", torch.Tensor(pixel_mean).view(-1, 1, 1), False
+        )
+        self.register_buffer("pixel_std", torch.Tensor(pixel_std).view(-1, 1, 1), False)
+
+    @property
+    def device(self) -> Any:
+        return self.pixel_mean.device
+
+    def forward(
+        self,
+        batched_input: List[Dict[str, Any]],
+        multimask_output: bool,
+    ) -> List[Dict[str, torch.Tensor]]:
+        """
+        Predicts masks end-to-end from provided images and prompts.
+        If prompts are not known in advance, using SamPredictor is
+        recommended over calling the model directly.
+
+        Arguments:
+          batched_input (list(dict)): A list over input images, each a
+            dictionary with the following keys. A prompt key can be
+            excluded if it is not present.
+              'image': The image as a torch tensor in 3xHxW format,
+                already transformed for input to the model.
+              'original_size': (tuple(int, int)) The original size of
+                the image before transformation, as (H, W).
+              'point_coords': (torch.Tensor) Batched point prompts for
+                this image, with shape BxNx2. Already transformed to the
+                input frame of the model.
+              'point_labels': (torch.Tensor) Batched labels for point prompts,
+                with shape BxN.
+              'boxes': (torch.Tensor) Batched box inputs, with shape Bx4.
+                Already transformed to the input frame of the model.
+              'mask_inputs': (torch.Tensor) Batched mask inputs to the model,
+                in the form Bx1xHxW.
+          multimask_output (bool): Whether the model should predict multiple
+            disambiguating masks, or return a single mask.
+
+        Returns:
+          (list(dict)): A list over input images, where each element is
+            as dictionary with the following keys.
+              'masks': (torch.Tensor) Batched binary mask predictions,
+                with shape BxCxHxW, where B is the number of input prompts,
+                C is determined by multimask_output, and (H, W) is the
+                original size of the image.
+              'iou_predictions': (torch.Tensor) The model's predictions
+                of mask quality, in shape BxC.
+              'low_res_logits': (torch.Tensor) Low resolution logits with
+                shape BxCxHxW, where H=W=256. Can be passed as mask input
+                to subsequent iterations of prediction.
+        """
+        input_images = torch.stack(
+            [self.preprocess(x["image"]) for x in batched_input], dim=0
+        )
+        image_embeddings = self.image_encoder(input_images)
+
+        outputs = []
+        for image_record, curr_embedding in zip(batched_input, image_embeddings):
+            if "point_coords" in image_record:
+                points = (image_record["point_coords"], image_record["point_labels"])
+            else:
+                points = None
+            sparse_embeddings, dense_embeddings = self.prompt_encoder(
+                points=points,
+                boxes=image_record.get("boxes", None),
+                masks=image_record.get("mask_inputs", None),
+            )
+            low_res_masks, iou_predictions = self.mask_decoder(
+                image_embeddings=curr_embedding.unsqueeze(0),
+                image_pe=self.prompt_encoder.get_dense_pe(),
+                sparse_prompt_embeddings=sparse_embeddings,
+                dense_prompt_embeddings=dense_embeddings,
+                multimask_output=multimask_output,
+            )
+            masks = self.postprocess_masks(
+                low_res_masks,
+                input_size=image_record["image"].shape[-2:],
+                original_size=image_record["original_size"],
+            )
+            masks = masks > self.mask_threshold
+            outputs.append(
+                {
+                    "masks": masks,
+                    "iou_predictions": iou_predictions,
+                    "low_res_logits": low_res_masks,
+                }
+            )
+        return outputs
+
+    def postprocess_masks(
+        self,
+        masks: torch.Tensor,
+        input_size: Tuple[int, ...],
+        original_size: Tuple[int, ...],
+    ) -> torch.Tensor:
+        """
+        Remove padding and upscale masks to the original image size.
+
+        Arguments:
+          masks (torch.Tensor): Batched masks from the mask_decoder,
+            in BxCxHxW format.
+          input_size (tuple(int, int)): The size of the image input to the
+            model, in (H, W) format. Used to remove padding.
+          original_size (tuple(int, int)): The original size of the image
+            before resizing for input to the model, in (H, W) format.
+
+        Returns:
+          (torch.Tensor): Batched masks in BxCxHxW format, where (H, W)
+            is given by original_size.
+        """
+        masks = F.interpolate(
+            masks,
+            (self.image_encoder.img_size, self.image_encoder.img_size),
+            mode="bilinear",
+            align_corners=False,
+        )
+        masks = masks[..., : input_size[0], : input_size[1]]
+        masks = F.interpolate(
+            masks, original_size, mode="bilinear", align_corners=False
+        )
+        return masks
+
+    def preprocess(self, x: torch.Tensor) -> torch.Tensor:
+        """Normalize pixel values and pad to a square input."""
+        # Normalize colors
+        x = (x - self.pixel_mean) / self.pixel_std
+
+        # Pad
+        h, w = x.shape[-2:]
+        padh = self.image_encoder.img_size - h
+        padw = self.image_encoder.img_size - w
+        x = F.pad(x, (0, padw, 0, padh))
+        return x
+
+
+def build_sam_vit_t(checkpoint=None):
+    prompt_embed_dim = 256
+    image_size = 1024
+    vit_patch_size = 16
+    image_embedding_size = image_size // vit_patch_size
+    mobile_sam = MobileSam(
+        image_encoder=TinyViT(
+            img_size=1024,
+            in_chans=3,
+            num_classes=1000,
+            embed_dims=[64, 128, 160, 320],
+            depths=[2, 2, 6, 2],
+            num_heads=[2, 4, 5, 10],
+            window_sizes=[7, 7, 14, 7],
+            mlp_ratio=4.0,
+            drop_rate=0.0,
+            drop_path_rate=0.0,
+            use_checkpoint=False,
+            mbconv_expand_ratio=4.0,
+            local_conv_size=3,
+            layer_lr_decay=0.8,
+        ),
+        prompt_encoder=PromptEncoder(
+            embed_dim=prompt_embed_dim,
+            image_embedding_size=(image_embedding_size, image_embedding_size),
+            input_image_size=(image_size, image_size),
+            mask_in_chans=16,
+        ),
+        mask_decoder=MaskDecoder(
+            num_multimask_outputs=3,
+            transformer=TwoWayTransformer(
+                depth=2,
+                embedding_dim=prompt_embed_dim,
+                mlp_dim=2048,
+                num_heads=8,
+            ),
+            transformer_dim=prompt_embed_dim,
+            iou_head_depth=3,
+            iou_head_hidden_dim=256,
+        ),
+        pixel_mean=[123.675, 116.28, 103.53],
+        pixel_std=[58.395, 57.12, 57.375],
+    )
+
+    mobile_sam.eval()
+    if checkpoint is not None:
+        with open(checkpoint, "rb") as f:
+            state_dict = torch.load(f)
+        mobile_sam.load_state_dict(state_dict)
+    return mobile_sam
+
+
 ######### JoliGEN level functions
 def load_sam_weight(model_path):
     if "vit_h" in model_path:
@@ -452,6 +682,12 @@ def load_sam_weight(model_path):
     elif "vit_b" in model_path:
         model_type = "vit_b"
     sam = sam_model_registry[model_type](checkpoint=model_path)
+    sam_predictor = SamPredictorG(sam)
+    return sam, sam_predictor
+
+
+def load_mobile_sam_weight(model_path):
+    sam = build_sam_vit_t(checkpoint=model_path)
     sam_predictor = SamPredictorG(sam)
     return sam, sam_predictor
 
@@ -724,7 +960,6 @@ def predict_sam_edges(
 
     batched_edges = []
     for k in range(len(image)):
-        pass
         masked_imgs = []
         for mask in batched_output[k]["non_redundant_masks"]:
             assert (
@@ -874,14 +1109,25 @@ def compute_mask_with_sam(img, rect_mask, sam_model, device, batched=True):
                     predictor=predictor,
                     cat=categories[i],
                 )
-                """
-                xmin, ymin, xmax, ymax = boxes[i].cpu()
-                mask[: int(ymin), :] = 0
-                mask[int(ymax) :, :] = 0
-                mask[:, : int(xmin)] = 0
-                mask[:, int(xmax) :] = 0
-                """
                 sam_masks[i] = torch.from_numpy(mask).unsqueeze(0)
             else:
                 sam_masks[i] = rect_mask[i]
         return sam_masks
+
+
+def init_sam_net(model_type_sam, model_path, device):
+    if model_type_sam == "sam":
+        download_sam_weight(path=model_path)
+        freezenet_sam, predictor_sam = load_sam_weight(model_path=model_path)
+        if device is not None:
+            freezenet_sam = freezenet_sam.to(device)
+    elif model_type_sam == "mobile_sam":
+        download_mobile_sam_weight(path=model_path)
+        freezenet_sam, predictor_sam = load_mobile_sam_weight(model_path=model_path)
+        if device is not None:
+            freezenet_sam.to(device)
+    else:
+        raise ValueError(
+            f'{model_type_sam} is not a correct choice for model_type_sam.\nChoices: ["sam", "mobile_sam"]'
+        )
+    return freezenet_sam, predictor_sam

--- a/models/modules/utils.py
+++ b/models/modules/utils.py
@@ -241,24 +241,46 @@ def download_midas_weight(model_type="DPT_Large"):
 
 
 def download_sam_weight(path):
-    sam_weights = {
-        "sam_vit_h_4b8939.pth": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth",
-        "sam_vit_l_0b3195.pth": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth",
-        "sam_vit_b_01ec64.pth": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth",
-    }
-    for i in range(2, len(path.split("/"))):
-        temp = path.split("/")[:i]
-        cur_path = "/".join(temp)
-        if not os.path.isdir(cur_path):
-            os.mkdir(cur_path)
-    model_name = path.split("/")[-1]
-    if model_name in sam_weights:
-        wget.download(sam_weights[model_name], path)
-    else:
-        raise NameError(
-            "There is no pretrained weight to download for %s, you need to provide a path to segformer weights."
-            % model_name
-        )
+    if not os.path.exists(path):
+        if not "mobile_sam" in path:
+            sam_weights = {
+                "sam_vit_h_4b8939.pth": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth",
+                "sam_vit_l_0b3195.pth": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_l_0b3195.pth",
+                "sam_vit_b_01ec64.pth": "https://dl.fbaipublicfiles.com/segment_anything/sam_vit_b_01ec64.pth",
+            }
+            for i in range(2, len(path.split("/"))):
+                temp = path.split("/")[:i]
+                cur_path = "/".join(temp)
+                if not os.path.isdir(cur_path):
+                    os.mkdir(cur_path)
+            model_name = path.split("/")[-1]
+            if model_name in sam_weights:
+                wget.download(sam_weights[model_name], path)
+            else:
+                raise NameError(
+                    "There is no pretrained weight to download for %s, you need to provide a path to sam weights."
+                    % model_name
+                )
+        else:
+            download_mobile_sam_weight(path)
+
+
+def download_mobile_sam_weight(path):
+    if not os.path.exists(path):
+        sam_weights = "https://github.com/ChaoningZhang/MobileSAM/raw/master/weights/mobile_sam.pt"
+        for i in range(2, len(path.split("/"))):
+            temp = path.split("/")[:i]
+            cur_path = "/".join(temp)
+            if not os.path.isdir(cur_path):
+                os.mkdir(cur_path)
+        model_name = path.split("/")[-1]
+        if model_name in sam_weights:
+            wget.download(sam_weights, path)
+        else:
+            raise NameError(
+                "There is no pretrained weight to download for %s, you need to provide a path to mobileSam weights."
+                % model_name
+            )
 
 
 def predict_depth(img, midas, model_type):

--- a/models/semantic_networks.py
+++ b/models/semantic_networks.py
@@ -1,16 +1,19 @@
 import os
 
 from .modules.classifiers import (
+    TORCH_MODEL_CLASSES,
     Classifier,
     VGG16_FCN8s,
     torch_model,
-    TORCH_MODEL_CLASSES,
 )
-from .modules.UNet_classification import UNet
+from .modules.sam.sam_inference import (
+    init_sam_net,
+    load_mobile_sam_weight,
+    load_sam_weight,
+)
 from .modules.segformer.segformer_generator import Segformer
-
-from .modules.utils import init_net, get_weights
-from .modules.sam.sam_inference import load_sam_weight
+from .modules.UNet_classification import UNet
+from .modules.utils import get_weights, init_net
 
 
 def define_C(
@@ -22,7 +25,7 @@ def define_C(
     model_init_type,
     model_init_gain,
     train_sem_cls_pretrained,
-    **unused_options
+    **unused_options,
 ):
     img_size = data_crop_size
     if train_sem_cls_template == "basic":
@@ -43,6 +46,7 @@ def define_f(
     f_s_net,
     model_input_nc,
     f_s_semantic_nclasses,
+    model_type_sam,
     model_init_type,
     model_init_gain,
     f_s_config_segformer,
@@ -50,7 +54,7 @@ def define_f(
     f_s_weight_sam,
     jg_dir,
     data_crop_size,
-    **unused_options
+    **unused_options,
 ):
     if f_s_net == "vgg":
         net = VGG16_FCN8s(
@@ -95,7 +99,7 @@ def define_f(
                 net.net.load_state_dict(weights, strict=False)
         return net
     elif f_s_net == "sam":
-        net, mg = load_sam_weight(f_s_weight_sam)
+        net, mg = init_sam_net(model_type_sam, f_s_weight_sam, device=None)
         return net, mg
 
     return init_net(net, model_init_type, model_init_gain)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ onnx
 aim
 git+https://github.com/facebookresearch/segment-anything.git
 piq
-
+git+https://github.com/ChaoningZhang/MobileSAM.git

--- a/tests/test_run_semantic_mask_online.py
+++ b/tests/test_run_semantic_mask_online.py
@@ -36,6 +36,7 @@ json_like_dict = {
     "train_sem_use_label_B": True,
     "data_relative_paths": True,
     "D_netDs": ["basic", "projected_d", "temporal"],
+    "D_weight_sam": "models/configs/sam/pretrain/mobile_sam.pt",
     "train_gan_mode": "projected",
     "D_proj_interp": 256,
     "train_G_ema": True,
@@ -59,22 +60,32 @@ G_netG = ["mobile_resnet_attn", "segformer_attn_conv"]
 
 D_proj_network_type = ["efficientnet", "vitsmall"]
 
+D_netDs = [["basic", "projected_d", "temporal"], ["sam"]]
+
 f_s_net = ["unet"]
 
-product_list = product(models_semantic_mask, G_netG, D_proj_network_type, f_s_net)
+model_type_sam = ["mobile_sam"]
+
+product_list = product(
+    models_semantic_mask, G_netG, D_proj_network_type, D_netDs, f_s_net, model_type_sam
+)
 
 
 def test_semantic_mask_online(dataroot):
     json_like_dict["dataroot"] = dataroot
     json_like_dict["checkpoints_dir"] = "/".join(dataroot.split("/")[:-1])
 
-    for model, Gtype, Dtype, f_s_type in product_list:
+    for model, Gtype, Dtype, Dnet, f_s_type, sam_type in product_list:
+        if model == "cycle_gan" and "sam" in Dnet:
+            continue
         json_like_dict_c = json_like_dict.copy()
         json_like_dict_c["model_type"] = model
         json_like_dict_c["name"] += "_" + model
         json_like_dict_c["G_netG"] = Gtype
         json_like_dict_c["D_proj_network_type"] = Dtype
+        json_like_dict_c["D_netDs"] = Dnet
         json_like_dict_c["f_s_net"] = f_s_type
+        json_like_dict_c["model_type_sam"] = sam_type
 
         opt = TrainOptions().parse_json(json_like_dict_c)
         train.launch_training(opt)


### PR DESCRIPTION
# MobileSAM [2306.14289]
JoliGEN implementation to use [MobileSAM](https://github.com/ChaoningZhang/MobileSAM) for GANs and Diffusion models.

# Usage
- GANs: `python3 train.py [...] --D_netDs sam --D_weight_mobile_sam models/configs/sam/pretrain/mobile_sam.pt --f_s_weight_mobile_sam models/configs/sam/pretrain/mobile_sam.pt --model_type_sam mobile_sam (default)`  
- Diffusion
    - Mask refinement: `python3 train.py [...] --data_refined_mask --f_s_weight_mobile_sam models/configs/sam/pretrain/mobile_sam.pt --model_type_sam mobile_sam (default)`
    - Edge detection: `python3 train.py [...] --alg_palette_cond_image_creation computed_sketch --alg_palette_computed_sketch_list sam -f_s_weight_mobile_sam models/configs/sam/pretrain/mobile_sam.pt --model_type_sam mobile_sam (default)`

\+ fixed some example config files because the shape of `mask_delta` has changed (from list of int to list of list)

>  "For the inference with MobileSAM, a single image takes runs only around
    10ms: 8ms on the image encoder and 2ms on the mask decoder. It is worth highlighting that our MobileSAM is 7 
    times smaller and 4 times faster than the concurrent FastSAM Zhao et al., while achieving superior 
    performance."
> -- *Zhang et al.*