### PR TITLE
chore: D_netDs values in documentation

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -384,7 +384,7 @@ class BaseOptions:
                 "sam",
             ]
             + list(TORCH_MODEL_CLASSES.keys()),
-            help="specify discriminator architecture, D_n_layers allows you to specify the layers in the discriminator. NB: duplicated arguments will be ignored.",
+            help="specify discriminator architecture, another option, --D_n_layers allows you to specify the layers in the n_layers discriminator. NB: duplicated arguments are ignored. Values: basic, n_layers, pixel, projected_d, temporal, vision_aided, depth, mask, sam",
             nargs="+",
         )
         parser.add_argument(


### PR DESCRIPTION
In documentation, https://www.joligen.com/doc/options.html `--D_netDs` does not show the different options, because they are dynamically created at runtime, put them into the option description instead.