### PR TITLE
feat(ml): GAN mask generator with sam refined target

### DIFF
--- a/models/base_gan_model.py
+++ b/models/base_gan_model.py
@@ -108,7 +108,7 @@ class BaseGanModel(BaseModel):
         else:
             self.use_depth = False
 
-        if "sam" in opt.D_netDs:
+        if "sam" in opt.D_netDs or opt.data_refined_mask:
             self.use_sam = True
             self.netfreeze_sam, self.predictor_sam = load_sam_weight(
                 self.opt.D_weight_sam

--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -453,6 +453,8 @@ class CUTModel(BaseGanModel):
 
         if "mask" in self.opt.D_netDs:
             visual_names_seg_B += ["real_mask_B_inv", "fake_mask_B_inv"]
+            if self.opt.data_refined_mask:
+                visual_names_seg_B += ["label_sam_B"]
 
         self.visual_names += [visual_names_seg_A, visual_names_seg_B]
 


### PR DESCRIPTION
This PR complements #411 with automatically refined mask target obtained with SAM.

Details: using mask semantics, masks may not have the same shape in A and B domains, e.g. when replacing a small object with a larger one. In practice, masks in A need to be modified (with `--data_online_creation_mask_delta_A`) to roughly accommodate the surface of the corresponding mask in B. This is so the semantic constraint can apply.
This PR allows `f_s` to automatically create a predictive mask for A that matches masks in B.

Example usage:
```
--D_netDs projected_d basic sam mask  --train_mask_no_train_f_s_A --train_mask_f_s_B --f_s_all_classes_as_one --data_refined_mask
```

