### PR TITLE
fix: training examples with mask_delta

### DIFF
--- a/docs/source/training.rst
+++ b/docs/source/training.rst
@@ -97,7 +97,7 @@ Trains a diffusion model to insert glasses onto faces.
 
 .. code:: bash
 
-   python3 train.py --dataroot noglasses2glasses_ffhq --checkpoints_dir ./checkpoints --name glasses2noglasses --output_display_env glasses2noglasses --config_json examples/example_ddpm_glasses2noglasses.json
+   python3 train.py --dataroot /path/to/data/noglasses2glasses_ffhq --checkpoints_dir /path/to/checkpoints --name noglasses2glasses --config_json examples/example_ddpm_noglasses2glasses.json
    
 
 

--- a/examples/example_ddpm_noglasses2glasses.json
+++ b/examples/example_ddpm_noglasses2glasses.json
@@ -115,10 +115,10 @@
             "load_size_A": [],
             "load_size_B": [],
             "mask_delta_A": [
-                0
+                []
             ],
             "mask_delta_B": [
-                0
+                []
             ],
             "mask_random_offset_A": [
                 0.0
@@ -157,17 +157,6 @@
         "semantic_nclasses": 2,
         "semantic_threshold": 1.0,
         "weight_sam": "",
-        "weight_segformer": ""
-    },
-    "cls": {
-        "all_classes_as_one": false,
-        "class_weights": [],
-        "config_segformer": "models/configs/segformer/segformer_config_b0.py",
-        "dropout": false,
-        "net": "vgg",
-        "nf": 64,
-        "semantic_nclasses": 2,
-        "semantic_threshold": 1.0,
         "weight_segformer": ""
     },
     "output": {

--- a/examples/example_gan_mario2sonic.json
+++ b/examples/example_gan_mario2sonic.json
@@ -62,17 +62,13 @@
             "load_size_A": [],
             "load_size_B": [],
             "mask_delta_A": [
-		50
-	    ],
+                [50]
+            ],
             "mask_delta_B": [
-		15
-	    ],
-            "mask_random_offset_A": [
-                0.0
+                [15]
             ],
-            "mask_random_offset_B": [
-                0.0
-            ],
+            "mask_random_offset_A": [0.0],
+            "mask_random_offset_B": [0.0],
             "mask_square_A": false,
             "mask_square_B": false,
             "rand_mask_A": false
@@ -99,20 +95,9 @@
         "dropout": false,
         "net": "unet",
         "nf": 64,
-        "semantic_nclasses": 2,
+        "semantic_nclasses": 7,
         "semantic_threshold": 1.0,
         "weight_sam": "",
-        "weight_segformer": ""
-    },
-    "cls": {
-        "all_classes_as_one": false,
-        "class_weights": [],
-        "config_segformer": "models/configs/segformer/segformer_config_b0.py",
-        "dropout": false,
-        "net": "vgg",
-        "nf": 64,
-        "semantic_nclasses": 2,
-        "semantic_threshold": 1.0,
         "weight_segformer": ""
     },
     "output": {

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -1023,53 +1023,48 @@ class BaseOptions:
             ):
                 raise ValueError("SAM with masks and bbox prompting requires Pytorch 2")
         if opt.f_s_net == "sam" and opt.data_dataset_mode == "unaligned_labeled_mask":
-            raise warning.warn("SAM with direct masks does not use mask/bbox prompting")
+            warnings.warn("SAM with direct masks does not use mask/bbox prompting")
 
         # mask delta check
-        if opt.data_online_creation_mask_delta_A == None:
+        if opt.data_online_creation_mask_delta_A == [[]]:
             pass
         else:
             if (
-                len(opt.data_online_creation_mask_delta_A) > 1
-                and len(opt.data_online_creation_mask_delta_A)
+                len(opt.data_online_creation_mask_delta_A)
                 < opt.f_s_semantic_nclasses - 1
             ):
+                if len(opt.data_online_creation_mask_delta_A) == 1:
+                    warnings.warn(
+                        "Mask delta A list should be of length f_s_semantic_nclasses, distributing single value across all classes"
+                    )
+                opt.data_online_creation_mask_delta_A = (
+                    opt.data_online_creation_mask_delta_A
+                    * (opt.f_s_semantic_nclasses - 1)
+                )
+            elif len(opt.data_online_creation_mask_delta_A) > 1:
                 raise ValueError(
                     "Mask delta A list must be of length f_s_semantic_nclasses"
                 )
-            if (
-                len(opt.data_online_creation_mask_delta_A)
-                == opt.f_s_semantic_nclasses - 1
-            ):
-                if (
-                    len(opt.data_online_creation_mask_delta_A[0]) == 1
-                    and not opt.data_online_creation_mask_square_A
-                ):
-                    raise ValueError(
-                        "Mask delta A has a single value per dimension but --data_online_creation_mask_square_A is not set, please set it to True"
-                    )
-        if opt.data_online_creation_mask_delta_B == None:
+
+        if opt.data_online_creation_mask_delta_B == [[]]:
             pass
         else:
             if (
-                len(opt.data_online_creation_mask_delta_B) > 1
-                and len(opt.data_online_creation_mask_delta_B)
+                len(opt.data_online_creation_mask_delta_B)
                 < opt.f_s_semantic_nclasses - 1
             ):
+                if len(opt.data_online_creation_mask_delta_B) == 1:
+                    warnings.warn(
+                        "Mask delta B list should be of length f_s_semantic_nclasses, distributing single value across all classes"
+                    )
+                opt.data_online_creation_mask_delta_B = (
+                    opt.data_online_creation_mask_delta_B
+                    * (opt.f_s_semantic_nclasses - 1)
+                )
+            elif len(opt.data_online_creation_mask_delta_B) > 1:
                 raise ValueError(
                     "Mask delta B list must be of length f_s_semantic_nclasses"
                 )
-            if (
-                len(opt.data_online_creation_mask_delta_B)
-                == opt.f_s_semantic_nclasses - 1
-            ):
-                if (
-                    len(opt.data_online_creation_mask_delta_B[0]) == 1
-                    and not opt.data_online_creation_mask_square_B
-                ):
-                    raise ValueError(
-                        "Mask delta B has a single value per dimension but --data_online_creation_mask_square_B is not set, please set it to True"
-                    )
 
         self.opt = opt
 


### PR DESCRIPTION
This PR fixes documentation, example model configurations, and allows automatic redistribution of `mask_delta` single value across all classes.