### PR TITLE
fix: temporal end of sequence

### DIFF
--- a/data/self_supervised_temporal_dataset.py
+++ b/data/self_supervised_temporal_dataset.py
@@ -27,15 +27,17 @@ class SelfSupervisedTemporalDataset(TemporalLabeledMaskOnlineDataset):
         B_label_cls=None,
         index=None,
     ):
-        result = super().get_img(
-            A_img_path,
-            A_label_mask_path,
-            A_label_cls,
-            B_img_path,
-            B_label_mask_path,
-            B_label_cls,
-            index,
-        )
+        result = None
+        while result is None:
+            result = super().get_img(
+                A_img_path,
+                A_label_mask_path,
+                A_label_cls,
+                B_img_path,
+                B_label_mask_path,
+                B_label_cls,
+                index,
+            )
 
         try:
             A_img_list = [result["A"][0]]


### PR DESCRIPTION
This PR fixes a bug that had a None value being returned when a data loading sequence could not be fulfilled. This was breaking multi-GPU diffusion training with short sequences.

Current solution is to redraw a starting image, hopefully getting a full sequence. There's a risk of infinite looping atm, but that would indicate that the dataset is improperly constructed.