### PR TITLE
feat(ml): ability to train in wavelet space, similar to 2102.06108

### DIFF
--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -13,6 +13,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     python3-pip \
     python3-opencv \
     python3-pytest \
+    ninja-build \
     sudo \
     wget \
     git \

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -720,8 +720,13 @@ class BaseModel(ABC):
                         input_nc += self.opt.train_mm_nz
 
                     # onnx
-                    if not "ittr" in self.opt.G_netG and not (
-                        torch.__version__[0] == "2" and "segformer" in self.opt.G_netG
+                    if (
+                        not self.opt.train_feat_wavelet
+                        and not "ittr" in self.opt.G_netG
+                        and not (
+                            torch.__version__[0] == "2"
+                            and "segformer" in self.opt.G_netG
+                        )
                     ):  # XXX: segformer export fails with ONNX and Pytorch2
                         export_path_onnx = save_path.replace(".pth", ".onnx")
 

--- a/models/diffusion_networks.py
+++ b/models/diffusion_networks.py
@@ -47,6 +47,7 @@ def define_G(
     resblock_updown=True,
     use_new_attention_order=False,
     f_s_semantic_nclasses=-1,
+    train_feat_wavelet=False,
     **unused_options
 ):
     """Create a generator
@@ -102,6 +103,7 @@ def define_G(
             group_norm_size=G_unet_mha_group_norm_size,
             efficient=G_unet_mha_vit_efficient,
             cond_embed_dim=cond_embed_dim,
+            freq_space=train_feat_wavelet,
         )
 
     elif G_netG == "uvit":
@@ -124,6 +126,7 @@ def define_G(
             num_transformer_blocks=G_uvit_num_transformer_blocks,
             efficient=G_unet_mha_vit_efficient,
             cond_embed_dim=alg_palette_cond_embed_dim,
+            freq_space=train_feat_wavelet,
         )
         cond_embed_dim = alg_palette_cond_embed_dim
 

--- a/models/gan_networks.py
+++ b/models/gan_networks.py
@@ -69,6 +69,7 @@ def define_G(
     G_unet_mha_channel_mults,
     G_unet_mha_norm_layer,
     G_unet_mha_group_norm_size,
+    train_feat_wavelet,
     **unused_options
 ):
     """Create a generator
@@ -148,6 +149,7 @@ def define_G(
             use_spectral=G_spectral,
             padding_type=G_padding_type,
             twice_resnet_blocks=G_backward_compatibility_twice_resnet_blocks,
+            freq_space=train_feat_wavelet,
         )
     elif G_netG == "mobile_resnet_attn":
         net = ResnetGenerator_attn(
@@ -161,6 +163,7 @@ def define_G(
             padding_type=G_padding_type,
             mobile=True,
             twice_resnet_blocks=G_backward_compatibility_twice_resnet_blocks,
+            freq_space=train_feat_wavelet,
         )
     elif G_netG == "stylegan2":
         net = StyleGAN2Generator(
@@ -264,6 +267,7 @@ def define_D(
     dataaug_D_diffusion,
     f_s_semantic_nclasses,
     model_depth_network,
+    train_feat_wavelet,
     **unused_options
 ):
 
@@ -316,6 +320,7 @@ def define_D(
                 norm_layer=norm_layer,
                 use_dropout=D_dropout,
                 use_spectral=D_spectral,
+                freq_space=train_feat_wavelet,
             )
             return_nets[netD] = init_net(net, model_init_type, model_init_gain)
 

--- a/models/modules/op/__init__.py
+++ b/models/modules/op/__init__.py
@@ -1,0 +1,2 @@
+# from .fused_act import FusedLeakyReLU, fused_leaky_relu
+from .upfirdn2d import upfirdn2d

--- a/models/modules/op/upfirdn2d.cpp
+++ b/models/modules/op/upfirdn2d.cpp
@@ -1,0 +1,31 @@
+#include <ATen/ATen.h>
+#include <torch/extension.h>
+
+torch::Tensor upfirdn2d_op(const torch::Tensor &input,
+                           const torch::Tensor &kernel, int up_x, int up_y,
+                           int down_x, int down_y, int pad_x0, int pad_x1,
+                           int pad_y0, int pad_y1);
+
+#define CHECK_CUDA(x)                                                          \
+  TORCH_CHECK(x.type().is_cuda(), #x " must be a CUDA tensor")
+#define CHECK_CONTIGUOUS(x)                                                    \
+  TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
+#define CHECK_INPUT(x)                                                         \
+  CHECK_CUDA(x);                                                               \
+  CHECK_CONTIGUOUS(x)
+
+torch::Tensor upfirdn2d(const torch::Tensor &input, const torch::Tensor &kernel,
+                        int up_x, int up_y, int down_x, int down_y, int pad_x0,
+                        int pad_x1, int pad_y0, int pad_y1) {
+  CHECK_INPUT(input);
+  CHECK_INPUT(kernel);
+
+  at::DeviceGuard guard(input.device());
+
+  return upfirdn2d_op(input, kernel, up_x, up_y, down_x, down_y, pad_x0, pad_x1,
+                      pad_y0, pad_y1);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("upfirdn2d", &upfirdn2d, "upfirdn2d (CUDA)");
+}

--- a/models/modules/op/upfirdn2d.py
+++ b/models/modules/op/upfirdn2d.py
@@ -1,0 +1,209 @@
+from collections import abc
+import os
+
+import torch
+from torch.nn import functional as F
+from torch.autograd import Function
+from torch.utils.cpp_extension import load
+
+
+module_path = os.path.dirname(__file__)
+upfirdn2d_op = load(
+    "upfirdn2d",
+    sources=[
+        os.path.join(module_path, "upfirdn2d.cpp"),
+        os.path.join(module_path, "upfirdn2d_kernel.cu"),
+    ],
+)
+
+
+class UpFirDn2dBackward(Function):
+    @staticmethod
+    def forward(
+        ctx, grad_output, kernel, grad_kernel, up, down, pad, g_pad, in_size, out_size
+    ):
+
+        up_x, up_y = up
+        down_x, down_y = down
+        g_pad_x0, g_pad_x1, g_pad_y0, g_pad_y1 = g_pad
+
+        grad_output = grad_output.reshape(-1, out_size[0], out_size[1], 1)
+
+        grad_input = upfirdn2d_op.upfirdn2d(
+            grad_output,
+            grad_kernel,
+            down_x,
+            down_y,
+            up_x,
+            up_y,
+            g_pad_x0,
+            g_pad_x1,
+            g_pad_y0,
+            g_pad_y1,
+        )
+        grad_input = grad_input.view(in_size[0], in_size[1], in_size[2], in_size[3])
+
+        ctx.save_for_backward(kernel)
+
+        pad_x0, pad_x1, pad_y0, pad_y1 = pad
+
+        ctx.up_x = up_x
+        ctx.up_y = up_y
+        ctx.down_x = down_x
+        ctx.down_y = down_y
+        ctx.pad_x0 = pad_x0
+        ctx.pad_x1 = pad_x1
+        ctx.pad_y0 = pad_y0
+        ctx.pad_y1 = pad_y1
+        ctx.in_size = in_size
+        ctx.out_size = out_size
+
+        return grad_input
+
+    @staticmethod
+    def backward(ctx, gradgrad_input):
+        (kernel,) = ctx.saved_tensors
+
+        gradgrad_input = gradgrad_input.reshape(-1, ctx.in_size[2], ctx.in_size[3], 1)
+
+        gradgrad_out = upfirdn2d_op.upfirdn2d(
+            gradgrad_input,
+            kernel,
+            ctx.up_x,
+            ctx.up_y,
+            ctx.down_x,
+            ctx.down_y,
+            ctx.pad_x0,
+            ctx.pad_x1,
+            ctx.pad_y0,
+            ctx.pad_y1,
+        )
+        # gradgrad_out = gradgrad_out.view(ctx.in_size[0], ctx.out_size[0], ctx.out_size[1], ctx.in_size[3])
+        gradgrad_out = gradgrad_out.view(
+            ctx.in_size[0], ctx.in_size[1], ctx.out_size[0], ctx.out_size[1]
+        )
+
+        return gradgrad_out, None, None, None, None, None, None, None, None
+
+
+class UpFirDn2d(Function):
+    @staticmethod
+    def forward(ctx, input, kernel, up, down, pad):
+        up_x, up_y = up
+        down_x, down_y = down
+        pad_x0, pad_x1, pad_y0, pad_y1 = pad
+
+        kernel_h, kernel_w = kernel.shape
+        batch, channel, in_h, in_w = input.shape
+        ctx.in_size = input.shape
+
+        input = input.reshape(-1, in_h, in_w, 1)
+
+        ctx.save_for_backward(kernel, torch.flip(kernel, [0, 1]))
+
+        out_h = (in_h * up_y + pad_y0 + pad_y1 - kernel_h + down_y) // down_y
+        out_w = (in_w * up_x + pad_x0 + pad_x1 - kernel_w + down_x) // down_x
+        ctx.out_size = (out_h, out_w)
+
+        ctx.up = (up_x, up_y)
+        ctx.down = (down_x, down_y)
+        ctx.pad = (pad_x0, pad_x1, pad_y0, pad_y1)
+
+        g_pad_x0 = kernel_w - pad_x0 - 1
+        g_pad_y0 = kernel_h - pad_y0 - 1
+        g_pad_x1 = in_w * up_x - out_w * down_x + pad_x0 - up_x + 1
+        g_pad_y1 = in_h * up_y - out_h * down_y + pad_y0 - up_y + 1
+
+        ctx.g_pad = (g_pad_x0, g_pad_x1, g_pad_y0, g_pad_y1)
+
+        out = upfirdn2d_op.upfirdn2d(
+            input, kernel, up_x, up_y, down_x, down_y, pad_x0, pad_x1, pad_y0, pad_y1
+        )
+        # out = out.view(major, out_h, out_w, minor)
+        out = out.view(-1, channel, out_h, out_w)
+
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        kernel, grad_kernel = ctx.saved_tensors
+
+        grad_input = None
+
+        if ctx.needs_input_grad[0]:
+            grad_input = UpFirDn2dBackward.apply(
+                grad_output,
+                kernel,
+                grad_kernel,
+                ctx.up,
+                ctx.down,
+                ctx.pad,
+                ctx.g_pad,
+                ctx.in_size,
+                ctx.out_size,
+            )
+
+        return grad_input, None, None, None, None
+
+
+def upfirdn2d(input, kernel, up=1, down=1, pad=(0, 0)):
+    if not isinstance(up, abc.Iterable):
+        up = (up, up)
+
+    if not isinstance(down, abc.Iterable):
+        down = (down, down)
+
+    if len(pad) == 2:
+        pad = (pad[0], pad[1], pad[0], pad[1])
+
+    if input.device.type == "cpu":
+        out = upfirdn2d_native(input, kernel, *up, *down, *pad)
+
+    else:
+        out = UpFirDn2d.apply(input, kernel, up, down, pad)
+
+    return out
+
+
+def upfirdn2d_native(
+    input, kernel, up_x, up_y, down_x, down_y, pad_x0, pad_x1, pad_y0, pad_y1
+):
+    _, channel, in_h, in_w = input.shape
+    input = input.reshape(-1, in_h, in_w, 1)
+
+    _, in_h, in_w, minor = input.shape
+    kernel_h, kernel_w = kernel.shape
+
+    out = input.view(-1, in_h, 1, in_w, 1, minor)
+    out = F.pad(out, [0, 0, 0, up_x - 1, 0, 0, 0, up_y - 1])
+    out = out.view(-1, in_h * up_y, in_w * up_x, minor)
+
+    out = F.pad(
+        out, [0, 0, max(pad_x0, 0), max(pad_x1, 0), max(pad_y0, 0), max(pad_y1, 0)]
+    )
+    out = out[
+        :,
+        max(-pad_y0, 0) : out.shape[1] - max(-pad_y1, 0),
+        max(-pad_x0, 0) : out.shape[2] - max(-pad_x1, 0),
+        :,
+    ]
+
+    out = out.permute(0, 3, 1, 2)
+    out = out.reshape(
+        [-1, 1, in_h * up_y + pad_y0 + pad_y1, in_w * up_x + pad_x0 + pad_x1]
+    )
+    w = torch.flip(kernel, [0, 1]).view(1, 1, kernel_h, kernel_w)
+    out = F.conv2d(out, w)
+    out = out.reshape(
+        -1,
+        minor,
+        in_h * up_y + pad_y0 + pad_y1 - kernel_h + 1,
+        in_w * up_x + pad_x0 + pad_x1 - kernel_w + 1,
+    )
+    out = out.permute(0, 2, 3, 1)
+    out = out[:, ::down_y, ::down_x, :]
+
+    out_h = (in_h * up_y + pad_y0 + pad_y1 - kernel_h + down_y) // down_y
+    out_w = (in_w * up_x + pad_x0 + pad_x1 - kernel_w + down_x) // down_x
+
+    return out.view(-1, channel, out_h, out_w)

--- a/models/modules/op/upfirdn2d_kernel.cu
+++ b/models/modules/op/upfirdn2d_kernel.cu
@@ -1,0 +1,369 @@
+// Copyright (c) 2019, NVIDIA Corporation. All rights reserved.
+//
+// This work is made available under the Nvidia Source Code License-NC.
+// To view a copy of this license, visit
+// https://nvlabs.github.io/stylegan2/license.html
+
+#include <torch/types.h>
+
+#include <ATen/ATen.h>
+#include <ATen/AccumulateType.h>
+#include <ATen/cuda/CUDAApplyUtils.cuh>
+#include <ATen/cuda/CUDAContext.h>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+static __host__ __device__ __forceinline__ int floor_div(int a, int b) {
+  int c = a / b;
+
+  if (c * b > a) {
+    c--;
+  }
+
+  return c;
+}
+
+struct UpFirDn2DKernelParams {
+  int up_x;
+  int up_y;
+  int down_x;
+  int down_y;
+  int pad_x0;
+  int pad_x1;
+  int pad_y0;
+  int pad_y1;
+
+  int major_dim;
+  int in_h;
+  int in_w;
+  int minor_dim;
+  int kernel_h;
+  int kernel_w;
+  int out_h;
+  int out_w;
+  int loop_major;
+  int loop_x;
+};
+
+template <typename scalar_t>
+__global__ void upfirdn2d_kernel_large(scalar_t *out, const scalar_t *input,
+                                       const scalar_t *kernel,
+                                       const UpFirDn2DKernelParams p) {
+  int minor_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int out_y = minor_idx / p.minor_dim;
+  minor_idx -= out_y * p.minor_dim;
+  int out_x_base = blockIdx.y * p.loop_x * blockDim.y + threadIdx.y;
+  int major_idx_base = blockIdx.z * p.loop_major;
+
+  if (out_x_base >= p.out_w || out_y >= p.out_h ||
+      major_idx_base >= p.major_dim) {
+    return;
+  }
+
+  int mid_y = out_y * p.down_y + p.up_y - 1 - p.pad_y0;
+  int in_y = min(max(floor_div(mid_y, p.up_y), 0), p.in_h);
+  int h = min(max(floor_div(mid_y + p.kernel_h, p.up_y), 0), p.in_h) - in_y;
+  int kernel_y = mid_y + p.kernel_h - (in_y + 1) * p.up_y;
+
+  for (int loop_major = 0, major_idx = major_idx_base;
+       loop_major < p.loop_major && major_idx < p.major_dim;
+       loop_major++, major_idx++) {
+    for (int loop_x = 0, out_x = out_x_base;
+         loop_x < p.loop_x && out_x < p.out_w; loop_x++, out_x += blockDim.y) {
+      int mid_x = out_x * p.down_x + p.up_x - 1 - p.pad_x0;
+      int in_x = min(max(floor_div(mid_x, p.up_x), 0), p.in_w);
+      int w = min(max(floor_div(mid_x + p.kernel_w, p.up_x), 0), p.in_w) - in_x;
+      int kernel_x = mid_x + p.kernel_w - (in_x + 1) * p.up_x;
+
+      const scalar_t *x_p =
+          &input[((major_idx * p.in_h + in_y) * p.in_w + in_x) * p.minor_dim +
+                 minor_idx];
+      const scalar_t *k_p = &kernel[kernel_y * p.kernel_w + kernel_x];
+      int x_px = p.minor_dim;
+      int k_px = -p.up_x;
+      int x_py = p.in_w * p.minor_dim;
+      int k_py = -p.up_y * p.kernel_w;
+
+      scalar_t v = 0.0f;
+
+      for (int y = 0; y < h; y++) {
+        for (int x = 0; x < w; x++) {
+          v += static_cast<scalar_t>(*x_p) * static_cast<scalar_t>(*k_p);
+          x_p += x_px;
+          k_p += k_px;
+        }
+
+        x_p += x_py - w * x_px;
+        k_p += k_py - w * k_px;
+      }
+
+      out[((major_idx * p.out_h + out_y) * p.out_w + out_x) * p.minor_dim +
+          minor_idx] = v;
+    }
+  }
+}
+
+template <typename scalar_t, int up_x, int up_y, int down_x, int down_y,
+          int kernel_h, int kernel_w, int tile_out_h, int tile_out_w>
+__global__ void upfirdn2d_kernel(scalar_t *out, const scalar_t *input,
+                                 const scalar_t *kernel,
+                                 const UpFirDn2DKernelParams p) {
+  const int tile_in_h = ((tile_out_h - 1) * down_y + kernel_h - 1) / up_y + 1;
+  const int tile_in_w = ((tile_out_w - 1) * down_x + kernel_w - 1) / up_x + 1;
+
+  __shared__ volatile float sk[kernel_h][kernel_w];
+  __shared__ volatile float sx[tile_in_h][tile_in_w];
+
+  int minor_idx = blockIdx.x;
+  int tile_out_y = minor_idx / p.minor_dim;
+  minor_idx -= tile_out_y * p.minor_dim;
+  tile_out_y *= tile_out_h;
+  int tile_out_x_base = blockIdx.y * p.loop_x * tile_out_w;
+  int major_idx_base = blockIdx.z * p.loop_major;
+
+  if (tile_out_x_base >= p.out_w | tile_out_y >= p.out_h |
+      major_idx_base >= p.major_dim) {
+    return;
+  }
+
+  for (int tap_idx = threadIdx.x; tap_idx < kernel_h * kernel_w;
+       tap_idx += blockDim.x) {
+    int ky = tap_idx / kernel_w;
+    int kx = tap_idx - ky * kernel_w;
+    scalar_t v = 0.0;
+
+    if (kx < p.kernel_w & ky < p.kernel_h) {
+      v = kernel[(p.kernel_h - 1 - ky) * p.kernel_w + (p.kernel_w - 1 - kx)];
+    }
+
+    sk[ky][kx] = v;
+  }
+
+  for (int loop_major = 0, major_idx = major_idx_base;
+       loop_major < p.loop_major & major_idx < p.major_dim;
+       loop_major++, major_idx++) {
+    for (int loop_x = 0, tile_out_x = tile_out_x_base;
+         loop_x < p.loop_x & tile_out_x < p.out_w;
+         loop_x++, tile_out_x += tile_out_w) {
+      int tile_mid_x = tile_out_x * down_x + up_x - 1 - p.pad_x0;
+      int tile_mid_y = tile_out_y * down_y + up_y - 1 - p.pad_y0;
+      int tile_in_x = floor_div(tile_mid_x, up_x);
+      int tile_in_y = floor_div(tile_mid_y, up_y);
+
+      __syncthreads();
+
+      for (int in_idx = threadIdx.x; in_idx < tile_in_h * tile_in_w;
+           in_idx += blockDim.x) {
+        int rel_in_y = in_idx / tile_in_w;
+        int rel_in_x = in_idx - rel_in_y * tile_in_w;
+        int in_x = rel_in_x + tile_in_x;
+        int in_y = rel_in_y + tile_in_y;
+
+        scalar_t v = 0.0;
+
+        if (in_x >= 0 & in_y >= 0 & in_x < p.in_w & in_y < p.in_h) {
+          v = input[((major_idx * p.in_h + in_y) * p.in_w + in_x) *
+                        p.minor_dim +
+                    minor_idx];
+        }
+
+        sx[rel_in_y][rel_in_x] = v;
+      }
+
+      __syncthreads();
+      for (int out_idx = threadIdx.x; out_idx < tile_out_h * tile_out_w;
+           out_idx += blockDim.x) {
+        int rel_out_y = out_idx / tile_out_w;
+        int rel_out_x = out_idx - rel_out_y * tile_out_w;
+        int out_x = rel_out_x + tile_out_x;
+        int out_y = rel_out_y + tile_out_y;
+
+        int mid_x = tile_mid_x + rel_out_x * down_x;
+        int mid_y = tile_mid_y + rel_out_y * down_y;
+        int in_x = floor_div(mid_x, up_x);
+        int in_y = floor_div(mid_y, up_y);
+        int rel_in_x = in_x - tile_in_x;
+        int rel_in_y = in_y - tile_in_y;
+        int kernel_x = (in_x + 1) * up_x - mid_x - 1;
+        int kernel_y = (in_y + 1) * up_y - mid_y - 1;
+
+        scalar_t v = 0.0;
+
+#pragma unroll
+        for (int y = 0; y < kernel_h / up_y; y++)
+#pragma unroll
+          for (int x = 0; x < kernel_w / up_x; x++)
+            v += sx[rel_in_y + y][rel_in_x + x] *
+                 sk[kernel_y + y * up_y][kernel_x + x * up_x];
+
+        if (out_x < p.out_w & out_y < p.out_h) {
+          out[((major_idx * p.out_h + out_y) * p.out_w + out_x) * p.minor_dim +
+              minor_idx] = v;
+        }
+      }
+    }
+  }
+}
+
+torch::Tensor upfirdn2d_op(const torch::Tensor &input,
+                           const torch::Tensor &kernel, int up_x, int up_y,
+                           int down_x, int down_y, int pad_x0, int pad_x1,
+                           int pad_y0, int pad_y1) {
+  int curDevice = -1;
+  cudaGetDevice(&curDevice);
+  cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+  UpFirDn2DKernelParams p;
+
+  auto x = input.contiguous();
+  auto k = kernel.contiguous();
+
+  p.major_dim = x.size(0);
+  p.in_h = x.size(1);
+  p.in_w = x.size(2);
+  p.minor_dim = x.size(3);
+  p.kernel_h = k.size(0);
+  p.kernel_w = k.size(1);
+  p.up_x = up_x;
+  p.up_y = up_y;
+  p.down_x = down_x;
+  p.down_y = down_y;
+  p.pad_x0 = pad_x0;
+  p.pad_x1 = pad_x1;
+  p.pad_y0 = pad_y0;
+  p.pad_y1 = pad_y1;
+
+  p.out_h = (p.in_h * p.up_y + p.pad_y0 + p.pad_y1 - p.kernel_h + p.down_y) /
+            p.down_y;
+  p.out_w = (p.in_w * p.up_x + p.pad_x0 + p.pad_x1 - p.kernel_w + p.down_x) /
+            p.down_x;
+
+  auto out =
+      at::empty({p.major_dim, p.out_h, p.out_w, p.minor_dim}, x.options());
+
+  int mode = -1;
+
+  int tile_out_h = -1;
+  int tile_out_w = -1;
+
+  if (p.up_x == 1 && p.up_y == 1 && p.down_x == 1 && p.down_y == 1 &&
+      p.kernel_h <= 4 && p.kernel_w <= 4) {
+    mode = 1;
+    tile_out_h = 16;
+    tile_out_w = 64;
+  }
+
+  if (p.up_x == 1 && p.up_y == 1 && p.down_x == 1 && p.down_y == 1 &&
+      p.kernel_h <= 3 && p.kernel_w <= 3) {
+    mode = 2;
+    tile_out_h = 16;
+    tile_out_w = 64;
+  }
+
+  if (p.up_x == 2 && p.up_y == 2 && p.down_x == 1 && p.down_y == 1 &&
+      p.kernel_h <= 4 && p.kernel_w <= 4) {
+    mode = 3;
+    tile_out_h = 16;
+    tile_out_w = 64;
+  }
+
+  if (p.up_x == 2 && p.up_y == 2 && p.down_x == 1 && p.down_y == 1 &&
+      p.kernel_h <= 2 && p.kernel_w <= 2) {
+    mode = 4;
+    tile_out_h = 16;
+    tile_out_w = 64;
+  }
+
+  if (p.up_x == 1 && p.up_y == 1 && p.down_x == 2 && p.down_y == 2 &&
+      p.kernel_h <= 4 && p.kernel_w <= 4) {
+    mode = 5;
+    tile_out_h = 8;
+    tile_out_w = 32;
+  }
+
+  if (p.up_x == 1 && p.up_y == 1 && p.down_x == 2 && p.down_y == 2 &&
+      p.kernel_h <= 2 && p.kernel_w <= 2) {
+    mode = 6;
+    tile_out_h = 8;
+    tile_out_w = 32;
+  }
+
+  dim3 block_size;
+  dim3 grid_size;
+
+  if (tile_out_h > 0 && tile_out_w > 0) {
+    p.loop_major = (p.major_dim - 1) / 16384 + 1;
+    p.loop_x = 1;
+    block_size = dim3(32 * 8, 1, 1);
+    grid_size = dim3(((p.out_h - 1) / tile_out_h + 1) * p.minor_dim,
+                     (p.out_w - 1) / (p.loop_x * tile_out_w) + 1,
+                     (p.major_dim - 1) / p.loop_major + 1);
+  } else {
+    p.loop_major = (p.major_dim - 1) / 16384 + 1;
+    p.loop_x = 4;
+    block_size = dim3(4, 32, 1);
+    grid_size = dim3((p.out_h * p.minor_dim - 1) / block_size.x + 1,
+                     (p.out_w - 1) / (p.loop_x * block_size.y) + 1,
+                     (p.major_dim - 1) / p.loop_major + 1);
+  }
+
+  AT_DISPATCH_FLOATING_TYPES_AND_HALF(x.scalar_type(), "upfirdn2d_cuda", [&] {
+    switch (mode) {
+    case 1:
+      upfirdn2d_kernel<scalar_t, 1, 1, 1, 1, 4, 4, 16, 64>
+          <<<grid_size, block_size, 0, stream>>>(out.data_ptr<scalar_t>(),
+                                                 x.data_ptr<scalar_t>(),
+                                                 k.data_ptr<scalar_t>(), p);
+
+      break;
+
+    case 2:
+      upfirdn2d_kernel<scalar_t, 1, 1, 1, 1, 3, 3, 16, 64>
+          <<<grid_size, block_size, 0, stream>>>(out.data_ptr<scalar_t>(),
+                                                 x.data_ptr<scalar_t>(),
+                                                 k.data_ptr<scalar_t>(), p);
+
+      break;
+
+    case 3:
+      upfirdn2d_kernel<scalar_t, 2, 2, 1, 1, 4, 4, 16, 64>
+          <<<grid_size, block_size, 0, stream>>>(out.data_ptr<scalar_t>(),
+                                                 x.data_ptr<scalar_t>(),
+                                                 k.data_ptr<scalar_t>(), p);
+
+      break;
+
+    case 4:
+      upfirdn2d_kernel<scalar_t, 2, 2, 1, 1, 2, 2, 16, 64>
+          <<<grid_size, block_size, 0, stream>>>(out.data_ptr<scalar_t>(),
+                                                 x.data_ptr<scalar_t>(),
+                                                 k.data_ptr<scalar_t>(), p);
+
+      break;
+
+    case 5:
+      upfirdn2d_kernel<scalar_t, 1, 1, 2, 2, 4, 4, 8, 32>
+          <<<grid_size, block_size, 0, stream>>>(out.data_ptr<scalar_t>(),
+                                                 x.data_ptr<scalar_t>(),
+                                                 k.data_ptr<scalar_t>(), p);
+
+      break;
+
+    case 6:
+      upfirdn2d_kernel<scalar_t, 1, 1, 2, 2, 4, 4, 8, 32>
+          <<<grid_size, block_size, 0, stream>>>(out.data_ptr<scalar_t>(),
+                                                 x.data_ptr<scalar_t>(),
+                                                 k.data_ptr<scalar_t>(), p);
+
+      break;
+
+    default:
+      upfirdn2d_kernel_large<scalar_t><<<grid_size, block_size, 0, stream>>>(
+          out.data_ptr<scalar_t>(), x.data_ptr<scalar_t>(),
+          k.data_ptr<scalar_t>(), p);
+    }
+  });
+
+  return out;
+}

--- a/models/modules/resnet_architecture/resnet_generator.py
+++ b/models/modules/resnet_architecture/resnet_generator.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 import math
 from models.modules.attn_network import BaseGenerator_attn
 from models.modules.mobile_modules import SeparableConv2d
+from ..utils import InverseHaarTransform, HaarTransform
 
 
 class ResnetBlock(nn.Module):
@@ -400,6 +401,7 @@ class ResnetGenerator_attn(BaseGenerator_attn):
         padding_type="reflect",
         mobile=False,
         twice_resnet_blocks=False,
+        freq_space=False,
     ):
         super(ResnetGenerator_attn, self).__init__(
             nb_mask_attn=nb_mask_attn, nb_mask_input=nb_mask_input
@@ -415,48 +417,68 @@ class ResnetGenerator_attn(BaseGenerator_attn):
         self.nb = n_blocks
         self.padding_type = padding_type
         self.twice_resnet_blocks = twice_resnet_blocks
+        self.freq_space = freq_space
 
-        self.conv1 = spectral_norm(nn.Conv2d(input_nc, ngf, 7, 1, 0), use_spectral)
+        if freq_space:
+            self.iwt = InverseHaarTransform(self.input_nc)
+            self.dwt = HaarTransform(self.input_nc)
+            self.input_nc = input_nc * 4
+
+        self.conv1 = spectral_norm(
+            nn.Conv2d(self.input_nc, self.ngf, 7, 1, 0), use_spectral
+        )
         self.input_nc = output_nc  # hack
-        self.conv1_norm = nn.InstanceNorm2d(ngf)
-        self.conv2 = spectral_norm(nn.Conv2d(ngf, ngf * 2, 3, 2, 1), use_spectral)
-        self.conv2_norm = nn.InstanceNorm2d(ngf * 2)
-        self.conv3 = spectral_norm(nn.Conv2d(ngf * 2, ngf * 4, 3, 2, 1), use_spectral)
-        self.conv3_norm = nn.InstanceNorm2d(ngf * 4)
+        self.conv1_norm = nn.InstanceNorm2d(self.ngf)
+        self.conv2 = spectral_norm(
+            nn.Conv2d(self.ngf, self.ngf * 2, 3, 2, 1), use_spectral
+        )
+        self.conv2_norm = nn.InstanceNorm2d(self.ngf * 2)
+        self.conv3 = spectral_norm(
+            nn.Conv2d(self.ngf * 2, self.ngf * 4, 3, 2, 1), use_spectral
+        )
+        self.conv3_norm = nn.InstanceNorm2d(self.ngf * 4)
 
         self.resnet_blocks = []
         for i in range(n_blocks):
             self.resnet_blocks.append(
-                resnet_block_attn(ngf * 4, 3, 1, self.padding_type, conv=conv)
+                resnet_block_attn(self.ngf * 4, 3, 1, self.padding_type, conv=conv)
             )
             self.resnet_blocks[i].weight_init(0, 0.02)
 
         self.resnet_blocks = nn.Sequential(*self.resnet_blocks)
 
         self.deconv1_content = spectral_norm(
-            nn.ConvTranspose2d(ngf * 4, ngf * 2, 3, 2, 1, 1), use_spectral
+            nn.ConvTranspose2d(self.ngf * 4, self.ngf * 2, 3, 2, 1, 1), use_spectral
         )
-        self.deconv1_norm_content = nn.InstanceNorm2d(ngf * 2)
+        self.deconv1_norm_content = nn.InstanceNorm2d(self.ngf * 2)
         self.deconv2_content = spectral_norm(
-            nn.ConvTranspose2d(ngf * 2, ngf, 3, 2, 1, 1), use_spectral
+            nn.ConvTranspose2d(self.ngf * 2, self.ngf, 3, 2, 1, 1), use_spectral
         )
-        self.deconv2_norm_content = nn.InstanceNorm2d(ngf)
+        self.deconv2_norm_content = nn.InstanceNorm2d(self.ngf)
+        if self.freq_space:
+            deconv3_ngf = int(self.ngf / 4)
+        else:
+            deconv3_ngf = self.ngf
         self.deconv3_content = spectral_norm(
             nn.Conv2d(
-                ngf, self.input_nc * (self.nb_mask_attn - self.nb_mask_input), 7, 1, 0
+                deconv3_ngf,
+                self.input_nc * (self.nb_mask_attn - self.nb_mask_input),
+                7,
+                1,
+                0,
             ),
             use_spectral,
         )
 
         self.deconv1_attention = spectral_norm(
-            nn.ConvTranspose2d(ngf * 4, ngf * 2, 3, 2, 1, 1), use_spectral
+            nn.ConvTranspose2d(self.ngf * 4, self.ngf * 2, 3, 2, 1, 1), use_spectral
         )
-        self.deconv1_norm_attention = nn.InstanceNorm2d(ngf * 2)
+        self.deconv1_norm_attention = nn.InstanceNorm2d(self.ngf * 2)
         self.deconv2_attention = spectral_norm(
-            nn.ConvTranspose2d(ngf * 2, ngf, 3, 2, 1, 1), use_spectral
+            nn.ConvTranspose2d(self.ngf * 2, self.ngf, 3, 2, 1, 1), use_spectral
         )
-        self.deconv2_norm_attention = nn.InstanceNorm2d(ngf)
-        self.deconv3_attention = nn.Conv2d(ngf, self.nb_mask_attn, 1, 1, 0)
+        self.deconv2_norm_attention = nn.InstanceNorm2d(self.ngf)
+        self.deconv3_attention = nn.Conv2d(self.ngf, self.nb_mask_attn, 1, 1, 0)
 
         self.tanh = nn.Tanh()
 
@@ -470,6 +492,10 @@ class ResnetGenerator_attn(BaseGenerator_attn):
             x = F.pad(input, (3, 3, 3, 3), "reflect")
         else:
             x = F.pad(input, (3, 3, 3, 3), "constant", 0)
+
+        if self.freq_space:
+            x = self.dwt(x)
+
         x = F.relu(self.conv1_norm(self.conv1(x)))
         x = F.relu(self.conv2_norm(self.conv2(x)))
         x = F.relu(self.conv3_norm(self.conv3(x)))
@@ -495,11 +521,16 @@ class ResnetGenerator_attn(BaseGenerator_attn):
 
         x_content = F.relu(self.deconv1_norm_content(self.deconv1_content(x)))
         x_content = F.relu(self.deconv2_norm_content(self.deconv2_content(x_content)))
+
+        if self.freq_space:
+            x_content = self.iwt(x_content)
+
         if self.padding_type == "reflect":
             x_content = F.pad(x_content, (3, 3, 3, 3), "reflect")
         else:
             x_content = F.pad(x_content, (3, 3, 3, 3), "constant", 0)
         content = self.deconv3_content(x_content)
+
         image = self.tanh(content)
 
         images = []

--- a/models/modules/unet_generator_attn/unet_generator_attn.py
+++ b/models/modules/unet_generator_attn/unet_generator_attn.py
@@ -22,6 +22,8 @@ from .unet_attn_utils import (
 
 from models.modules.diffusion_utils import gamma_embedding
 
+from ..utils import InverseHaarTransform, HaarTransform
+
 
 class EmbedBlock(nn.Module):
     """
@@ -58,16 +60,29 @@ class Upsample(nn.Module):
 
     """
 
-    def __init__(self, channels, use_conv, out_channel=None, efficient=False):
+    def __init__(
+        self, channels, use_conv, out_channel=None, efficient=False, freq_space=False
+    ):
         super().__init__()
         self.channels = channels
         self.out_channel = out_channel or channels
         self.use_conv = use_conv
+        self.freq_space = freq_space
+
+        if freq_space:
+            self.iwt = InverseHaarTransform(3)
+            self.dwt = HaarTransform(3)
+            self.channels = int(self.channels / 4)
+            self.out_channel = int(self.out_channel / 4)
+
         if use_conv:
             self.conv = nn.Conv2d(self.channels, self.out_channel, 3, padding=1)
         self.efficient = efficient
 
     def forward(self, x):
+        if self.freq_space:
+            x = self.iwt(x)
+
         assert x.shape[1] == self.channels
         if not self.efficient:
             x = F.interpolate(x, scale_factor=2, mode="nearest")
@@ -75,6 +90,10 @@ class Upsample(nn.Module):
             x = self.conv(x)
         if self.efficient:  # if efficient, we do the interpolation after the conv
             x = F.interpolate(x, scale_factor=2, mode="nearest")
+
+        if self.freq_space:
+            x = self.dwt(x)
+
         return x
 
 
@@ -85,11 +104,19 @@ class Downsample(nn.Module):
     :param use_conv: a bool determining if a convolution is applied.
     """
 
-    def __init__(self, channels, use_conv, out_channel=None):
+    def __init__(self, channels, use_conv, out_channel=None, freq_space=False):
         super().__init__()
         self.channels = channels
         self.out_channel = out_channel or channels
         self.use_conv = use_conv
+        self.freq_space = freq_space
+
+        if self.freq_space:
+            self.iwt = InverseHaarTransform(3)
+            self.dwt = HaarTransform(3)
+            self.channels = int(self.channels / 4)
+            self.out_channel = int(self.out_channel / 4)
+
         stride = 2
         if use_conv:
             self.op = nn.Conv2d(
@@ -100,8 +127,16 @@ class Downsample(nn.Module):
             self.op = nn.AvgPool2d(kernel_size=stride, stride=stride)
 
     def forward(self, x):
+        if self.freq_space:
+            x = self.iwt(x)
+
         assert x.shape[1] == self.channels
-        return self.op(x)
+        opx = self.op(x)
+
+        if self.freq_space:
+            opx = self.dwt(opx)
+
+        return opx
 
 
 class ResBlock(EmbedBlock):
@@ -132,6 +167,7 @@ class ResBlock(EmbedBlock):
         up=False,
         down=False,
         efficient=False,
+        freq_space=False,
     ):
         super().__init__()
         self.channels = channels
@@ -143,21 +179,21 @@ class ResBlock(EmbedBlock):
         self.use_scale_shift_norm = use_scale_shift_norm
         self.up = up
         self.efficient = efficient
-
-        self.in_layers = nn.Sequential(
-            normalization(channels, norm),
-            torch.nn.SiLU(),
-            nn.Conv2d(channels, self.out_channel, 3, padding=1),
-        )
-
+        self.freq_space = freq_space
         self.updown = up or down
 
+        self.in_layers = nn.Sequential(
+            normalization(self.channels, norm),
+            torch.nn.SiLU(),
+            nn.Conv2d(self.channels, self.out_channel, 3, padding=1),
+        )
+
         if up:
-            self.h_upd = Upsample(channels, False)
-            self.x_upd = Upsample(channels, False)
+            self.h_upd = Upsample(channels, False, freq_space=self.freq_space)
+            self.x_upd = Upsample(channels, False, freq_space=self.freq_space)
         elif down:
-            self.h_upd = Downsample(channels, False)
-            self.x_upd = Downsample(channels, False)
+            self.h_upd = Downsample(channels, False, freq_space=self.freq_space)
+            self.x_upd = Downsample(channels, False, freq_space=self.freq_space)
         else:
             self.h_upd = self.x_upd = nn.Identity()
 
@@ -196,7 +232,9 @@ class ResBlock(EmbedBlock):
     def _forward(self, x, emb):
         if self.updown:
             in_rest, in_conv = self.in_layers[:-1], self.in_layers[-1]
+
             h = in_rest(x)
+
             if self.efficient and self.up:
                 h = in_conv(h)
                 h = self.h_upd(h)
@@ -205,6 +243,7 @@ class ResBlock(EmbedBlock):
                 h = self.h_upd(h)
                 x = self.x_upd(x)
                 h = in_conv(h)
+
         else:
             h = self.in_layers(x)
         emb_out = self.emb_layers(emb).type(h.dtype)
@@ -400,6 +439,7 @@ class UNet(nn.Module):
         resblock_updown=True,
         use_new_attention_order=False,
         efficient=False,
+        freq_space=False,
     ):
         super().__init__()
 
@@ -420,13 +460,20 @@ class UNet(nn.Module):
         self.num_heads = num_heads
         self.num_head_channels = num_head_channels
         self.num_heads_upsample = num_heads_upsample
+        self.freq_space = freq_space
+
+        if self.freq_space:
+            self.iwt = InverseHaarTransform(3)
+            self.dwt = HaarTransform(3)
+            in_channel *= 4
+            out_channel *= 4
 
         if norm == "groupnorm":
             norm = norm + str(group_norm_size)
 
         self.cond_embed_dim = cond_embed_dim
 
-        ch = input_ch = int(channel_mults[0] * inner_channel)
+        ch = input_ch = int(channel_mults[0] * self.inner_channel)
         self.input_blocks = nn.ModuleList(
             [EmbedSequential(nn.Conv2d(in_channel, ch, 3, padding=1))]
         )
@@ -440,14 +487,15 @@ class UNet(nn.Module):
                         ch,
                         self.cond_embed_dim,
                         dropout,
-                        out_channel=int(mult * inner_channel),
+                        out_channel=int(mult * self.inner_channel),
                         use_checkpoint=use_checkpoint,
                         use_scale_shift_norm=use_scale_shift_norm,
                         norm=norm,
                         efficient=efficient,
+                        freq_space=self.freq_space,
                     )
                 ]
-                ch = int(mult * inner_channel)
+                ch = int(mult * self.inner_channel)
                 if ds in attn_res:
                     layers.append(
                         AttentionBlock(
@@ -475,9 +523,15 @@ class UNet(nn.Module):
                             down=True,
                             norm=norm,
                             efficient=efficient,
+                            freq_space=self.freq_space,
                         )
                         if resblock_updown
-                        else Downsample(ch, conv_resample, out_channel=out_ch)
+                        else Downsample(
+                            ch,
+                            conv_resample,
+                            out_channel=out_ch,
+                            freq_space=self.freq_space,
+                        )
                     )
                 )
                 ch = out_ch
@@ -494,6 +548,7 @@ class UNet(nn.Module):
                 use_scale_shift_norm=use_scale_shift_norm,
                 norm=norm,
                 efficient=efficient,
+                freq_space=self.freq_space,
             ),
             AttentionBlock(
                 ch,
@@ -510,6 +565,7 @@ class UNet(nn.Module):
                 use_scale_shift_norm=use_scale_shift_norm,
                 norm=norm,
                 efficient=efficient,
+                freq_space=self.freq_space,
             ),
         )
         self._feature_size += ch
@@ -523,14 +579,15 @@ class UNet(nn.Module):
                         ch + ich,
                         self.cond_embed_dim,
                         dropout,
-                        out_channel=int(inner_channel * mult),
+                        out_channel=int(self.inner_channel * mult),
                         use_checkpoint=use_checkpoint,
                         use_scale_shift_norm=use_scale_shift_norm,
                         norm=norm,
                         efficient=efficient,
+                        freq_space=self.freq_space,
                     )
                 ]
-                ch = int(inner_channel * mult)
+                ch = int(self.inner_channel * mult)
                 if ds in attn_res:
                     layers.append(
                         AttentionBlock(
@@ -554,9 +611,15 @@ class UNet(nn.Module):
                             up=True,
                             norm=norm,
                             efficient=efficient,
+                            freq_space=self.freq_space,
                         )
                         if resblock_updown
-                        else Upsample(ch, conv_resample, out_channel=out_ch)
+                        else Upsample(
+                            ch,
+                            conv_resample,
+                            out_channel=out_ch,
+                            freq_space=self.freq_space,
+                        )
                     )
                     ds //= 2
                 self.output_blocks.append(EmbedSequential(*layers))
@@ -601,6 +664,10 @@ class UNet(nn.Module):
         hs = []
 
         h = input.type(torch.float32)
+
+        if self.freq_space:
+            h = self.dwt(h)
+
         for module in self.input_blocks:
 
             h = module(h, emb)
@@ -617,7 +684,12 @@ class UNet(nn.Module):
             h = torch.cat([h, hs.pop()], dim=1)
             h = module(h, emb)
         h = h.type(input.dtype)
-        return self.out(h)
+        outh = self.out(h)
+
+        if self.freq_space:
+            outh = self.iwt(outh)
+
+        return outh
 
     def get_feats(self, input, extract_layer_ids):
         _, hs, _ = self.compute_feats(input, embed_gammas=None)
@@ -719,6 +791,7 @@ class UViT(nn.Module):
         use_new_attention_order=False,
         num_transformer_blocks=6,
         efficient=False,
+        freq_space=False,
     ):
         super().__init__()
 
@@ -739,6 +812,13 @@ class UViT(nn.Module):
         self.num_heads = num_heads
         self.num_head_channels = num_head_channels
         self.num_heads_upsample = num_heads_upsample
+        self.freq_space = freq_space
+
+        if self.freq_space:
+            self.iwt = InverseHaarTransform(3)
+            self.dwt = HaarTransform(3)
+            in_channel *= 4
+            out_channel *= 4
 
         if norm == "groupnorm":
             norm = norm + str(group_norm_size)
@@ -746,7 +826,7 @@ class UViT(nn.Module):
         self.cond_embed_dim = cond_embed_dim
         self.inner_channel = inner_channel
 
-        ch = input_ch = int(channel_mults[0] * inner_channel)
+        ch = input_ch = int(channel_mults[0] * self.inner_channel)
         self.input_blocks = nn.ModuleList(
             [EmbedSequential(nn.Conv2d(in_channel, ch, 3, padding=1))]
         )
@@ -760,20 +840,28 @@ class UViT(nn.Module):
                         ch,
                         cond_embed_dim,
                         dropout,
-                        out_channel=int(mult * inner_channel),
+                        out_channel=int(mult * self.inner_channel),
                         use_checkpoint=use_checkpoint,
                         use_scale_shift_norm=use_scale_shift_norm,
                         norm=norm,
+                        freq_space=self.freq_space,
                     )
                 ]
-                ch = int(mult * inner_channel)
+                ch = int(mult * self.inner_channel)
                 self.input_blocks.append(EmbedSequential(*layers))
                 self._feature_size += ch
                 input_block_chans.append(ch)
             if level != len(channel_mults) - 1:
                 out_ch = ch
                 self.input_blocks.append(
-                    EmbedSequential(Downsample(ch, conv_resample, out_channel=out_ch))
+                    EmbedSequential(
+                        Downsample(
+                            ch,
+                            conv_resample,
+                            out_channel=out_ch,
+                            freq_space=self.freq_space,
+                        )
+                    )
                 )
                 ch = out_ch
                 input_block_chans.append(ch)
@@ -807,18 +895,23 @@ class UViT(nn.Module):
                         ch + ich,
                         cond_embed_dim,
                         dropout,
-                        out_channel=int(inner_channel * mult),
+                        out_channel=int(self.inner_channel * mult),
                         use_checkpoint=use_checkpoint,
                         use_scale_shift_norm=use_scale_shift_norm,
                         norm=norm,
+                        freq_space=self.freq_space,
                     )
                 ]
-                ch = int(inner_channel * mult)
+                ch = int(self.inner_channel * mult)
                 if level and i == res_blocks[level]:
                     out_ch = ch
                     layers.append(
                         Upsample(
-                            ch, conv_resample, out_channel=out_ch, efficient=efficient
+                            ch,
+                            conv_resample,
+                            out_channel=out_ch,
+                            efficient=efficient,
+                            freq_space=self.freq_space,
                         )
                     )
                     ds //= 2
@@ -864,6 +957,10 @@ class UViT(nn.Module):
         hs = []
 
         h = input.type(torch.float32)
+
+        if self.freq_space:
+            h = self.dwt(h)
+
         for module in self.input_blocks:
             h = module(h, emb)
             hs.append(h)
@@ -886,7 +983,12 @@ class UViT(nn.Module):
             h = torch.cat([h, hs.pop()], dim=1)
             h = module(h, emb)
         h = h.type(input.dtype)
-        return self.out(h)
+        outh = self.out(h)
+
+        if self.freq_space:
+            outh = self.iwt(outh)
+
+        return outh
 
     def get_feats(self, input, extract_layer_ids):
         _, hs, _ = self.compute_feats(input, embed_gammas=None)

--- a/models/modules/utils.py
+++ b/models/modules/utils.py
@@ -12,6 +12,8 @@ from torchvision.models import vgg
 
 from util.util import tensor2im
 
+from .op import upfirdn2d
+
 ##########################################################
 # Fonctions used for networks initialisation
 ##########################################################
@@ -299,3 +301,60 @@ def predict_depth(img, midas, model_type):
     )
     prediction = midas(transform(img))  # .unsqueeze(dim=1)
     return prediction
+
+
+### functions for frequency space
+
+
+def get_haar_wavelet(in_channels):
+    haar_wav_l = 1 / (2**0.5) * torch.ones(1, 2)
+    haar_wav_h = 1 / (2**0.5) * torch.ones(1, 2)
+    haar_wav_h[0, 0] = -1 * haar_wav_h[0, 0]
+
+    haar_wav_ll = haar_wav_l.T * haar_wav_l
+    haar_wav_lh = haar_wav_h.T * haar_wav_l
+    haar_wav_hl = haar_wav_l.T * haar_wav_h
+    haar_wav_hh = haar_wav_h.T * haar_wav_h
+
+    return haar_wav_ll, haar_wav_lh, haar_wav_hl, haar_wav_hh
+
+
+class HaarTransform(nn.Module):
+    def __init__(self, in_channels):
+        super().__init__()
+
+        ll, lh, hl, hh = get_haar_wavelet(in_channels)
+
+        self.register_buffer("ll", ll)
+        self.register_buffer("lh", lh)
+        self.register_buffer("hl", hl)
+        self.register_buffer("hh", hh)
+
+    def forward(self, input):
+        ll = upfirdn2d(input, self.ll, down=2)
+        lh = upfirdn2d(input, self.lh, down=2)
+        hl = upfirdn2d(input, self.hl, down=2)
+        hh = upfirdn2d(input, self.hh, down=2)
+
+        return torch.cat((ll, lh, hl, hh), 1)
+
+
+class InverseHaarTransform(nn.Module):
+    def __init__(self, in_channels):
+        super().__init__()
+
+        ll, lh, hl, hh = get_haar_wavelet(in_channels)
+
+        self.register_buffer("ll", ll)
+        self.register_buffer("lh", -lh)
+        self.register_buffer("hl", -hl)
+        self.register_buffer("hh", hh)
+
+    def forward(self, input):
+        ll, lh, hl, hh = input.chunk(4, 1)
+        ll = upfirdn2d(ll, self.ll, up=2, pad=(1, 0, 1, 0))
+        lh = upfirdn2d(lh, self.lh, up=2, pad=(1, 0, 1, 0))
+        hl = upfirdn2d(hl, self.hl, up=2, pad=(1, 0, 1, 0))
+        hh = upfirdn2d(hh, self.hh, up=2, pad=(1, 0, 1, 0))
+
+        return ll + lh + hl + hh

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -1066,6 +1066,14 @@ class BaseOptions:
                     "Mask delta B list must be of length f_s_semantic_nclasses"
                 )
 
+        # training is frequency space only available for a few architectures atm
+        if opt.train_feat_wavelet:
+            if not opt.G_netG in ["mobile_resnet_attn", "unet_mha", "uvit"]:
+                raise ValueError(
+                    "Wavelet training is only available for mobile_resnet_attn, unet_mha and uvit architectures"
+                )
+
+        # register options
         self.opt = opt
 
         return self.opt

--- a/options/train_options.py
+++ b/options/train_options.py
@@ -282,6 +282,13 @@ class TrainOptions(BaseOptions):
         )
         parser.add_argument("--train_use_contrastive_loss_D", action="store_true")
 
+        # frequency space training
+        parser.add_argument(
+            "--train_feat_wavelet",
+            action="store_true",
+            help="if true, train in wavelet features space (Note: this may not include all discriminators, when training GANs)",
+        )
+
         # multimodal training
         parser.add_argument(
             "--train_mm_lambda_z",

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ aim
 git+https://github.com/facebookresearch/segment-anything.git
 piq
 git+https://github.com/ChaoningZhang/MobileSAM.git
+Ninja

--- a/tests/test_run_diffusion.py
+++ b/tests/test_run_diffusion.py
@@ -35,6 +35,7 @@ json_like_dict = {
 models_diffusion = ["palette"]
 G_netG = ["unet_mha", "uvit"]
 G_efficient = [True, False]
+train_feat_wavelet = [False, True]
 
 G_unet_mha_norm_layer = [
     "groupnorm",
@@ -55,6 +56,7 @@ product_list = product(
     G_unet_mha_norm_layer,
     alg_palette_conditioning,
     G_efficient,
+    train_feat_wavelet,
 )
 
 
@@ -62,7 +64,14 @@ def test_semantic_mask(dataroot):
     json_like_dict["dataroot"] = dataroot
     json_like_dict["checkpoints_dir"] = "/".join(dataroot.split("/")[:-1])
 
-    for model, Gtype, G_norm, alg_palette_conditioning, G_efficient in product_list:
+    for (
+        model,
+        Gtype,
+        G_norm,
+        alg_palette_conditioning,
+        G_efficient,
+        train_feat_wavelet,
+    ) in product_list:
 
         json_like_dict_c = json_like_dict.copy()
         json_like_dict_c["model_type"] = model
@@ -73,6 +82,7 @@ def test_semantic_mask(dataroot):
         json_like_dict_c["G_unet_mha_vit_efficient"] = G_efficient
 
         json_like_dict_c["alg_palette_conditioning"] = alg_palette_conditioning
+        json_like_dict_c["train_feat_wavelet"] = train_feat_wavelet
 
         opt = TrainOptions().parse_json(json_like_dict_c)
         train.launch_training(opt)

--- a/tests/test_run_nosemantic.py
+++ b/tests/test_run_nosemantic.py
@@ -16,8 +16,8 @@ json_like_dict = {
     "output_display_id": 0,
     "gpu_ids": "0",
     "data_dataset_mode": "unaligned",
-    "data_load_size": 180,
-    "data_crop_size": 180,
+    "data_load_size": 128,
+    "data_crop_size": 128,
     "train_n_epochs": 1,
     "train_n_epochs_decay": 0,
     "data_max_dataset_size": 10,
@@ -33,16 +33,19 @@ models_nosemantic = [
 
 D_netDs = [["projected_d", "basic"], ["projected_d", "basic", "depth"]]
 
-product_list = product(models_nosemantic, D_netDs)
+train_feat_wavelet = [False, True]
+
+product_list = product(models_nosemantic, D_netDs, train_feat_wavelet)
 
 
 def test_nosemantic(dataroot):
     json_like_dict["dataroot"] = dataroot
     json_like_dict["checkpoints_dir"] = "/".join(dataroot.split("/")[:-1])
 
-    for model, Dtype in product_list:
+    for model, Dtype, train_feat_wavelet in product_list:
         json_like_dict["model_type"] = model
         json_like_dict["D_netDs"] = Dtype
+        json_like_dict["train_feat_wavelet"] = train_feat_wavelet
         if model == "cycle_gan" and "depth" in Dtype:
             continue  # skip
 


### PR DESCRIPTION
This PR allows training models in Wavelet frequency space, inspired by SwaGAN https://arxiv.org/abs/2102.06108. 
Wavelet feature space applies to both GAN and Diffusion model training.

Added option:
`--train_feat_wavelet`

Notes:
- At the moment, only available for `mobile_resnet_attn` generator and `basic` discriminator.
- Using identical parameters with and without Wavelet feature space does not yield identical models. In frequency space the features have x4 channels and size/2. Thus keeping the same number of convolutional channels (`--G_ngf` and `--D_ngf`) may hamper performances. Using larger `ngf` values is expected to be a good practice in frequency space.
- Only works for dimensions that are powers of 2.
- Under testing