### PR TITLE
feat: specialized helpers for each model

### DIFF
--- a/models/palette_model.py
+++ b/models/palette_model.py
@@ -158,7 +158,7 @@ class PaletteModel(BaseDiffusionModel):
             "--alg_palette_sam_sobel_threshold",
             type=float,
             default=0.7,
-            help="sobel threshold in % of gradient magnitude",
+            help="sobel threshold in %% of gradient magnitude",
         )
 
         parser.add_argument(

--- a/options/__init__.py
+++ b/options/__init__.py
@@ -2,7 +2,7 @@
 import argparse
 from .base_options import BaseOptions
 from .train_options import TrainOptions
-from models import get_models_names, get_option_setter
+from .helpers import get_models_parsers
 
 
 def get_parser():
@@ -13,23 +13,3 @@ def get_parser():
     bo = BaseOptions()
     parser = bo.initialize(parser)
     return parser
-
-
-def get_models_parsers():
-    """
-    Create a dict {model_name: parser} in which each parser hold arguments
-    specific to a model
-    """
-    model_names = get_models_names()
-    model_parsers = {}
-
-    for model_name in model_names:
-        parser = argparse.ArgumentParser()
-        model_option_setter = get_option_setter(model_name)
-
-        try:
-            model_parsers[model_name] = model_option_setter(parser, True)
-        except:
-            pass
-
-    return model_parsers

--- a/options/common_options.py
+++ b/options/common_options.py
@@ -1,7 +1,9 @@
 import os
+import argparse
 from .base_options import BaseOptions
 from util.util import MAX_INT, pairs_of_ints, pairs_of_floats
 from models.modules.classifiers import TORCH_MODEL_CLASSES
+from models import get_models_names, get_option_setter
 import models
 import data
 
@@ -887,3 +889,30 @@ class CommonOptions(BaseOptions):
         opt = model_after_parse(opt)
 
         return opt
+
+    ### Functions related to CLI help
+    # "alg" topic contains model options instead of filtered common options
+
+    def topic_exists(self, topic):
+        if topic is not None and topic.startswith("alg_"):
+            return topic in self.get_topics("alg")
+        else:
+            return super().topic_exists(topic)
+
+    def get_topics(self, topic=None):
+        if topic == "alg":
+            return {
+                "alg_" + name: {"title": ""}
+                for name in get_models_names()
+                if name not in ["test", "template", "segmentation"]
+            }
+        else:
+            return super().get_topics(topic)
+
+    def get_topic_parser(self, topic):
+        if topic is not None and topic.startswith("alg_"):
+            model_name = topic[4:]
+            parser = argparse.ArgumentParser(add_help=False, usage=argparse.SUPPRESS)
+            return get_option_setter(model_name)(parser, True)
+        else:
+            return super().get_topic_parser(topic)

--- a/options/helpers.py
+++ b/options/helpers.py
@@ -1,0 +1,114 @@
+import argparse
+from models import get_models_names, get_option_setter
+
+
+def get_models_parsers():
+    """
+    Create a dict {model_name: parser} in which each parser hold arguments
+    specific to a model
+    """
+    model_names = get_models_names()
+    model_parsers = {}
+
+    for model_name in model_names:
+        parser = argparse.ArgumentParser()
+        model_option_setter = get_option_setter(model_name)
+
+        try:
+            model_parsers[model_name] = model_option_setter(parser, True)
+        except:
+            pass
+
+    return model_parsers
+
+
+# Help formatters
+
+
+class FilterArgumentParser(argparse.ArgumentParser):
+    """Parser that accepts only the option related to given topic"""
+
+    def __init__(self, keep_topics=None, remove_topics=None, **kwargs):
+        super(FilterArgumentParser, self).__init__(**kwargs)
+        self.keep_topics = keep_topics
+        self.remove_topics = remove_topics
+
+    def add_argument(self, *args, **kwargs):
+        opt_name = args[0]
+        opt_removed = False
+        if opt_name.startswith("--"):
+            # filter applies
+            if self.remove_topics:
+                for topic in self.remove_topics:
+                    if opt_name.startswith("--" + topic + "_"):
+                        opt_removed = True
+                        break
+
+            if self.keep_topics:
+                opt_found = False
+                for topic in self.keep_topics:
+                    if opt_name.startswith("--" + topic + "_"):
+                        opt_found = True
+                        break
+                if not opt_found:
+                    opt_removed = True
+
+        if not opt_removed:
+            super().add_argument(*args, **kwargs)
+
+
+class CustomHelpAction(argparse.Action):
+    def __init__(
+        self,
+        option_strings,
+        dest=argparse.SUPPRESS,
+        default=argparse.SUPPRESS,
+        help=None,
+    ):
+        super(CustomHelpAction, self).__init__(
+            option_strings=option_strings,
+            dest=dest,
+            default=default,
+            nargs="?",
+            help=help,
+        )
+
+    def __call__(self, parser, namespace, value, option_string=None):
+        from options import TrainOptions
+
+        options = TrainOptions()
+        topic = value
+        if not options.topic_exists(topic):
+            print("Unknown topic: %s\n" % topic)
+            topic = None
+
+        parser = options.get_topic_parser(topic)
+        parser.print_help()
+
+        subtopics = options.get_topics(topic)
+        if len(subtopics) > 0:
+            print(
+                "\n\nSelect topic to get help on associated options (--help [TOPIC]):\n"
+            )
+            BOLD = "\033[1m"
+            END = "\033[0m"
+            for key in subtopics:
+                subtopic = subtopics[key]
+                subtopic_desc = subtopic["title"] if "title" in subtopic else ""
+                print("\t%s%s%s\t\t%s" % (BOLD, key, END, subtopic_desc))
+
+        parser.exit()
+
+
+def set_custom_help(parser):
+    """
+    Change --help into this app's custom help
+    """
+    parser.register("action", "help", CustomHelpAction)
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        default=argparse.SUPPRESS,
+        help="show this help message and exit",
+    )

--- a/options/inference_diffusion_options.py
+++ b/options/inference_diffusion_options.py
@@ -197,7 +197,7 @@ class InferenceDiffusionOptions(BaseOptions):
             "--alg_palette_sam_sobel_threshold",
             type=float,
             default=0.7,
-            help="sobel threshold in %% of gradient magintude",
+            help="sobel threshold in %% of gradient magnitude",
         )
 
         parser.add_argument(

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -21,6 +21,43 @@ python3 ${current_dir}/../scripts/generate_doc.py --save_to ""
 OUT=$?
 
 if [ $OUT != 0 ]; then
+   exit 1
+fi
+
+####### CLI help
+echo "CLI help"
+python3 ${current_dir}/../train.py --help
+OUT=$?
+
+if [ $OUT != 0 ]; then
+    exit 1
+fi
+
+python3 ${current_dir}/../train.py --help f_s
+OUT=$?
+
+if [ $OUT != 0 ]; then
+    exit 1
+fi
+
+python3 ${current_dir}/../train.py --help alg
+OUT=$?
+
+if [ $OUT != 0 ]; then
+    exit 1
+fi
+
+python3 ${current_dir}/../train.py --help alg_cut
+OUT=$?
+
+if [ $OUT != 0 ]; then
+    exit 1
+fi
+
+python3 ${current_dir}/../train.py --help alg_palette
+OUT=$?
+
+if [ $OUT != 0 ]; then
     exit 1
 fi
 


### PR DESCRIPTION
```
>>> python train.py --help
usage: train.py --dataroot DATAROOT [--name NAME] [--suffix SUFFIX] [--gpu_ids GPU_IDS] [--with_amp] [--with_tf32] [--with_torch_compile] [--checkpoints_dir CHECKPOINTS_DIR] [--phase PHASE]
                [--ddp_port DDP_PORT] [--warning_mode] [--test_batch_size TEST_BATCH_SIZE]

optional arguments:
  --dataroot DATAROOT   path to images (should have subfolders trainA, trainB, valA, valB, etc) (default: None)
  --name NAME           name of the experiment. It decides where to store samples and models (default: experiment_name)
  --suffix SUFFIX       customized suffix: opt.name = opt.name + suffix: e.g., {model}_{netG}_size{load_size} (default: )
  --gpu_ids GPU_IDS     gpu ids: e.g. 0 0,1,2, 0,2. use -1 for CPU (default: 0)
  --with_amp            whether to activate torch amp on forward passes (default: False)
  --with_tf32           whether to activate tf32 for faster computations (Ampere GPU and beyond only) (default: False)
  --with_torch_compile  whether to activate torch.compile for some forward and backward functions (experimental) (default: False)
  --checkpoints_dir CHECKPOINTS_DIR
                        models are saved here (default: ./checkpoints)
  --phase PHASE         train, val, test, etc (default: train)
  --ddp_port DDP_PORT
  --warning_mode        whether to display warning (default: False)
  --test_batch_size TEST_BATCH_SIZE
                        input batch size (default: 1)

Select topic to get help on associated options (--help [TOPIC]):

        D               Discriminator
        G               Generator
        alg             Algorithm-specific
        data            Datasets
        f_s             Semantic segmentation network
        cls             Semantic classification network
        output          Output
        model           Model
        train           Training
        dataaug         Data augmentation
```
```
>>> python3 train.py --help f_s
optional arguments:
  --f_s_net {vgg,unet,segformer,sam}
                        specify f_s network [vgg|unet|segformer|sam] (default: vgg)
  --f_s_dropout         dropout for the semantic network (default: False)
  --f_s_semantic_nclasses F_S_SEMANTIC_NCLASSES
                        number of classes of the semantic loss classifier (default: 2)
  --f_s_class_weights [F_S_CLASS_WEIGHTS [F_S_CLASS_WEIGHTS ...]]
                        class weights for imbalanced semantic classes (default: [])
  --f_s_semantic_threshold F_S_SEMANTIC_THRESHOLD
                        threshold of the semantic classifier loss below with semantic loss is applied (default: 1.0)
  --f_s_all_classes_as_one
                        if true, all classes will be considered as the same one (ie foreground vs background) (default: False)
  --f_s_nf F_S_NF       # of filters in the first conv layer of classifier (default: 64)
  --f_s_config_segformer F_S_CONFIG_SEGFORMER
                        path to segformer configuration file for f_s (default: models/configs/segformer/segformer_config_b0.json)
  --f_s_weight_segformer F_S_WEIGHT_SEGFORMER
                        path to segformer weight for f_s, e.g. models/configs/segformer/pretrain/segformer_mit-b0.pth (default: )
  --f_s_weight_sam F_S_WEIGHT_SAM
                        path to sam weight for f_s, e.g. models/configs/sam/pretrain/sam_vit_b_01ec64.pth, or models/configs/sam/pretrain/mobile_sam.pt for MobileSAM (default: )
```
Aides sur les options des modèles:
```
>>> python3 train.py --help alg
optional arguments:
  --alg_re_adversarial_loss_p
                        if True, also train the prediction model with an adversarial loss (default: False)
  --alg_re_nuplet_size ALG_RE_NUPLET_SIZE
                        Number of frames loaded (default: 3)
  --alg_re_netP {resnet_9blocks,resnet_6blocks,resnet_attn,unet_256,unet_128}
                        specify P architecture (default: unet_128)
  --alg_re_no_train_P_fake_images
                        if True, P wont be trained over fake images projections (default: False)
  --alg_re_projection_threshold ALG_RE_PROJECTION_THRESHOLD
                        threshold of the real images projection loss below with fake projection and fake reconstruction losses are applied (default: 1.0)
  --alg_re_P_lr ALG_RE_P_LR
                        initial learning rate for P networks (default: 0.0002)


Select topic to get help on associated options (--help [TOPIC]):

        alg_palette
        alg_cut
        alg_cycle_gan
```