### PR TITLE
fix: reverse DDIM schedule

### DIFF
--- a/models/modules/diffusion_generator.py
+++ b/models/modules/diffusion_generator.py
@@ -286,7 +286,7 @@ class DiffusionGenerator(nn.Module):
 
         tlist = torch.zeros([y_t.shape[0]], device=y_t.device).long()
         for i in tqdm(
-            reversed(range(num_steps)),
+            range(num_steps),
             desc="sampling loop time step",
             total=num_steps,
         ):


### PR DESCRIPTION
In `restoration_ddpm`, we are looping in reverse order.
We start at `t = num_timesteps_test - 1` and end at `t = 0`.
We use gammas in reverse order.

In `restoration_ddim`, we were looping in reverse order, but we are already reversing `tseq` in `tlist` and `prevt`.
We started at `tlist = 0` and ended at `tlist = num_timesteps_test - 1`.
We used gammas in order.