### PR TITLE
fix: DDIM restoration when batch_size > 1

### DIFF
--- a/models/modules/diffusion_generator.py
+++ b/models/modules/diffusion_generator.py
@@ -378,12 +378,12 @@ class DiffusionGenerator(nn.Module):
             y_0_hat.clamp_(-1.0, 1.0)
 
         gamma_t = self.extract(
-            getattr(self.denoise_fn.model, "gammas_" + phase), t, x_shape=(1, 1)
+            getattr(self.denoise_fn.model, "gammas_" + phase), t, x_shape=(1, 1, 1, 1)
         ).to(y_t.device)
         gamma_prevt = self.extract(
             getattr(self.denoise_fn.model, "gammas_prev_" + phase),
             prevt + 1,
-            x_shape=(1, 1),
+            x_shape=(1, 1, 1, 1),
         ).to(y_t.device)
 
         ## denoising formula for model_mean witih DDIM


### PR DESCRIPTION
`y_t` shape is `(batch_size, 3, size, size)`
`gamma_t` and `gamma_prevt` shape should be `(batch_size, 1, 1, 1)` instead of `(batch_size, 1)`

failed here: https://github.com/jolibrain/joliGEN/blob/bd16f1ede7f194dd1f411edc54b70f6838f1e7b5/models/modules/diffusion_generator.py#L401-L403

```
RuntimeError: The size of tensor a (42) must match the size of tensor b (128) at non-singleton dimension 2