### PR TITLE
fixes: Missing bbox ref idx in from crop_image in gen_single_image_diffusion + allow inference on cpu

### DIFF
--- a/scripts/gen_single_image_diffusion.py
+++ b/scripts/gen_single_image_diffusion.py
@@ -75,7 +75,9 @@ def load_model(
     model.eval()
 
     # handle old models
-    weights = torch.load(modelpath + "/" + model_in_file)
+    weights = torch.load(
+        modelpath + "/" + model_in_file, map_location=torch.device(device)
+    )
     if opt.model_prior_321_backwardcompatibility:
         weights = {
             k.replace("denoise_fn.cond_embed", "cond_embed"): v
@@ -283,7 +285,7 @@ def generate(
             min_crop_bbox_ratio=min_crop_bbox_ratio,
         )
 
-        img, mask, ref_bbox = crop_image(
+        img, mask, ref_bbox, bbox_ref_id = crop_image(
             img_path=img_in,
             bbox_path=bbox_in,
             mask_delta=mask_delta,  # opt.data_online_creation_mask_delta_A,


### PR DESCRIPTION
# First issue
## Issue description
Got the following error after running `gen_single_image_diffusion.py`:
```
File "joliGEN/scripts/gen_single_image_diffusion.py", line 286, in generate
    img, mask, ref_bbox = crop_image(
ValueError: too many values to unpack (expected 3)
```

## Fix
Just added a fourth variable to store the `box_ref_idx` returned from `crop_image` to make the code run.

# Second issue
## Issue description
Got the following error after running `gen_single_image_diffusion.py` with option `--cpu`:
```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```
## Fix
Added what's advised in the error to fix the problem.