### PR TITLE
fix: inference_num for reference img

### DIFF
--- a/models/palette_model.py
+++ b/models/palette_model.py
@@ -656,7 +656,9 @@ class PaletteModel(BaseDiffusionModel):
                         cls=cur_class,
                         ddim_num_steps=self.ddim_num_steps,
                         ddim_eta=self.ddim_eta,
-                        ref=self.ref_A if hasattr(self, "ref_A") else None,
+                        ref=self.ref_A[: self.inference_num]
+                        if hasattr(self, "ref_A")
+                        else None,
                     )
 
                     name = "output_" + str(i + 1)


### PR DESCRIPTION
Inference used to fail when `inference_num` < `batch_size`.