### PR TITLE
fix: update python version for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,4 +7,4 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.8
+        language_version: python3.10


### PR DESCRIPTION
This PR changes the version of python used for pre-commit (from 3.8 to 3.10).