### PR TITLE
feat(ml): DinoV2 feature-based projected discriminator

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -443,6 +443,10 @@ class BaseOptions:
                 "vitclip16",
                 "vitclip14",
                 "depth",
+                "dinov2_vits14",
+                "dinov2_vitb14",
+                "dinov2_vitl14",
+                "dinov2_vitg14",
             ],
             help="projected discriminator architecture",
         )

--- a/tests/test_run_semantic_mask_online.py
+++ b/tests/test_run_semantic_mask_online.py
@@ -59,7 +59,7 @@ models_semantic_mask = [
 
 G_netG = ["mobile_resnet_attn", "segformer_attn_conv"]
 
-D_proj_network_type = ["efficientnet", "vitsmall"]
+D_proj_network_type = ["efficientnet", "vitsmall", "dinov2_vits14"]
 
 D_netDs = [
     ["basic", "projected_d"],


### PR DESCRIPTION
This PR adds DinoV2 projected discriminator. 

- DinoV2: https://arxiv.org/abs/2304.07193 and https://github.com/facebookresearch/dinov2
- DinoV2 discriminator used in StyleGAN-T, see https://arxiv.org/abs/2301.09515 and https://github.com/autonomousvision/stylegan-t
- Feature layers to be extracted are taken and scaled from https://github.com/autonomousvision/stylegan-t/blob/main/networks/discriminator.py#L108C53-L108C53