### PR TITLE
Consistency models with JoliGEN for inpainting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 [![Docs](https://github.com/jolibrain/joliGEN/actions/workflows/github-actions-doc-options-update.yml/badge.svg)](https://github.com/jolibrain/joliGEN/actions/workflows/github-actions-doc-options-update.yml)
 [![Website](https://img.shields.io/website-up-down-green-red/http/joligen.com/doc.svg)](https://www.joligen.com/doc)
 
-<h1 align="center">Generative AI Image Toolset with GANs and Diffusion for Real-World Applications</h1>
+<h1 align="center">Generative AI Image Toolset with GANs, Diffusion and Consistency Models for Real-World Applications</h1>
 
 **JoliGEN** is an integrated framework for training custom generative AI image-to-image models
 
 Main Features:
 
-- JoliGEN implements both **GAN and Diffusion models** for unpaired and paired image to image translation tasks, including domain and style adaptation with conservation of semantics such as image and object classes, masks, ...
+- JoliGEN implements both **GAN, Diffusion and Consistency models** for unpaired and paired image to image translation tasks, including domain and style adaptation with conservation of semantics such as image and object classes, masks, ...
 
 - JoliGEN generative AI capabilities are targeted at real world applications such as **Controled Image Generation**, **Augmented Reality**, **Dataset Smart Augmentation** and object insertion, **Synthetic to Real** transforms.
 

--- a/docs/source/inference.rst
+++ b/docs/source/inference.rst
@@ -214,7 +214,7 @@ The ``--cls`` parameter controls the pose for Mario (1 = standing, 2 = walking, 
 
    mkdir mario_inference_output
    cd scripts/
-   python3 gen_single_image_diffusion.py --model-in-file ../checkpoints/mario/latest_net_G_A.pth --img-in ../datasets/online_mario2sonic_lite/mario/imgs/mario_frame_19538.jpg --bbox-in ../datasets/online_mario2sonic_lite/mario/bbox/r_mario_frame_19538.jpg.txt --dir-out ../mario_inference_output --img-width 128 --img-height 128 --mask_delta 10 --cls 3
+   python3 gen_single_image_diffusion.py --model_in_file ../checkpoints/mario/latest_net_G_A.pth --img_in ../datasets/online_mario2sonic_lite/mario/imgs/mario_frame_19538.jpg --bbox_in ../datasets/online_mario2sonic_lite/mario/bbox/r_mario_frame_19538.jpg.txt --dir_out ../mario_inference_output --img_width 128 --img_height 128 --mask_delta 10 --cls 3
 
 The output files will be in the ``mario_inference_output`` folder, with:
 
@@ -282,7 +282,7 @@ The ``--cond-in`` parameter specifies the conditioning image to use.
 
    mkdir mapillary_inference_output
    cd scripts/
-   python3 gen_single_image_diffusion.py --model-in-file ../checkpoints/mapillary/latest_net_G_A.pth --img-in ../datasets/mapillary_lite/trainA/images/UbLxBV0FEP_FfEgGi0YhIA.jpg --bbox-in ../datasets/mapillary_lite/trainA/bbox/UbLxBV0FEP_FfEgGi0YhIA.txt --dir-out ../mapillary_inference_output --img-width 128 --img-height 128 --mask_delta 10 --alg_palette_cond_image_creation canny --alg_palette_sketch_canny_thresholds 100 400 --cond-in /path/to/conditioning_image.png
+   python3 gen_single_image_diffusion.py --model_in_file ../checkpoints/mapillary/latest_net_G_A.pth --img_in ../datasets/mapillary_lite/trainA/images/UbLxBV0FEP_FfEgGi0YhIA.jpg --bbox_in ../datasets/mapillary_lite/trainA/bbox/UbLxBV0FEP_FfEgGi0YhIA.txt --dir_out ../mapillary_inference_output --img_width 128 --img_height 128 --mask_delta 10 --alg_diffusion_cond_image_creation canny --alg_diffusion_sketch_canny_thresholds 100 400 --cond_in /path/to/conditioning_image.png
 
 The output files will be in the ``mapillary_inference_output`` folder, with:
 

--- a/docs/source/training.rst
+++ b/docs/source/training.rst
@@ -84,9 +84,9 @@ Dataset: https://joligen.com/datasets/online_mario2sonic_full.tar
 
 .. _training-object-insertion:
 
-***********************************
- DDPM training for object insertion
-***********************************
+************************************************
+ DDPM training for object insertion / inpainting
+************************************************
 
 Dataset: https://joligen.com/datasets/noglasses2glasses_ffhq.zip
 
@@ -154,3 +154,15 @@ Trains a diffusion model to generate an image conditioned by another image (supe
 .. code:: bash
 
    python3 train.py --dataroot /path/to/data/SEN2VEN_mini --checkpoints_dir /path/to/checkpoints --name SEN2VEN --config_json examples/example_ddpm_SEN2VEN.json
+
+*************************************************************
+ Consistency Model training for object insertion / inpainting
+*************************************************************
+
+Dataset: https://joligen.com/datasets/noglasses2glasses_ffhq.zip
+
+Trains a consistency model to insert glasses onto faces.
+
+.. code:: bash
+
+   python3 train.py --dataroot /path/to/data/noglasses2glasses_ffhq --checkpoints_dir /path/to/checkpoints --name noglasses2glasses --config_json examples/example_cm_noglasses2glasses.json

--- a/examples/example_cm_noglasses2glasses.json
+++ b/examples/example_cm_noglasses2glasses.json
@@ -16,6 +16,9 @@
         "proj_weight_segformer": "models/configs/segformer/pretrain/segformer_mit-b0.pth",
         "spectral": false,
         "temporal_every": 4,
+        "temporal_frame_step": 30,
+        "temporal_num_common_char": -1,
+        "temporal_number_frames": 5,
         "vision_aided_backbones": "clip+dino+swin",
         "weight_sam": ""
     },
@@ -27,7 +30,7 @@
         "diff_n_timestep_test": 1000,
         "diff_n_timestep_train": 2000,
         "dropout": false,
-        "nblocks": 9,
+        "nblocks": 2,
         "netE": "resnet_256",
         "netG": "unet_mha",
         "ngf": 64,
@@ -69,25 +72,21 @@
             "nuplet_size": 3,
             "projection_threshold": 1.0
         },
-	"palette": {
-	    "loss": "MSE",
-	    "sampling_method": "ddpm"
+	"cm": {
+	    "num_steps": 1000000
 	},
         "diffusion": {
             "computed_sketch_list": [
-                "canny"
+                "canny",
+                "hed"
             ],
-            "cond_embed_dim": 32,
-            "cond_image_creation": "computed_sketch",
+            "cond_embed_dim": 256,
+            "cond_image_creation": "y_t",
             "cond_embed": "",
-            "ddim_eta": 0.5,
-            "ddim_num_steps": 10,
-            "dropout_prob": 0.0,
             "generate_per_class": false,
             "inference_num": -1,
             "lambda_G": 1.0,
             "prob_use_previous_frame": 0.5,
-            "ref_embed_net": "clip",
             "sam_crop_delta": true,
             "sam_final_canny": false,
             "sam_max_mask_area": 0.99,
@@ -100,8 +99,8 @@
             "sam_sobel_threshold": 0.7,
             "sam_use_gaussian_filter": false,
             "sketch_canny_range": [
-                100,
-                400
+                0,
+                765
             ],
             "super_resolution_scale": 2.0,
             "task": "inpainting"
@@ -110,26 +109,20 @@
     "data": {
         "online_creation": {
             "color_mask_A": false,
-            "crop_delta_A": 30,
+            "crop_delta_A": 50,
             "crop_delta_B": 50,
             "crop_size_A": 128,
-            "crop_size_B": 512,
+            "crop_size_B": 128,
             "load_size_A": [],
             "load_size_B": [],
             "mask_delta_A": [
                 []
             ],
-            "mask_delta_A_ratio": [
-                []
-            ],
             "mask_delta_B": [
                 []
             ],
-            "mask_delta_B_ratio": [
-                []
-            ],
             "mask_random_offset_A": [
-                0.2
+                0.0
             ],
             "mask_random_offset_B": [
                 0.0
@@ -139,24 +132,21 @@
             "rand_mask_A": true
         },
         "crop_size": 128,
-        "dataset_mode": "self_supervised_labeled_mask_online",
-        "direction": "AtoB",
+        "dataset_mode": "self_supervised_labeled_mask",
+        "direction": "BtoA",
         "inverted_mask": false,
         "load_size": 128,
         "max_dataset_size": 1000000000,
-        "num_threads": 16,
+        "num_threads": 4,
         "online_context_pixels": 0,
         "online_fixed_mask_size": -1,
         "online_select_category": -1,
-        "online_single_bbox": true,
+        "online_single_bbox": false,
         "preprocess": "resize_and_crop",
         "refined_mask": false,
         "relative_paths": true,
         "sanitize_paths": false,
-        "serial_batches": false,
-        "temporal_frame_step": 30,
-        "temporal_num_common_char": -1,
-        "temporal_number_frames": 5
+        "serial_batches": false
     },
     "f_s": {
         "all_classes_as_one": false,
@@ -170,38 +160,26 @@
         "weight_sam": "",
         "weight_segformer": ""
     },
-    "cls": {
-        "all_classes_as_one": false,
-        "class_weights": [],
-        "config_segformer": "models/configs/segformer/segformer_config_b0.json",
-        "dropout": false,
-        "net": "vgg",
-        "nf": 64,
-        "semantic_nclasses": 2,
-        "semantic_threshold": 1.0,
-        "weight_segformer": ""
-    },
     "output": {
         "display": {
             "G_attention_masks": false,
             "aim_port": 53800,
             "aim_server": "http://localhost",
             "diff_fake_real": false,
-            "env": "",
-            "freq": 100000,
+            "env": "noglasses2glasses",
+            "freq": 1000,
             "id": 1,
             "ncols": 0,
             "networks": false,
             "type": [
                 "visdom"
             ],
-            "visdom_autostart": true,
             "visdom_port": 8097,
             "visdom_server": "http://localhost",
             "winsize": 256
         },
         "no_html": false,
-        "print_freq": 500,
+        "print_freq": 128,
         "update_html_freq": 1000,
         "verbose": false
     },
@@ -211,9 +189,7 @@
         "init_type": "normal",
         "input_nc": 3,
         "multimodal": false,
-        "output_nc": 3,
-        "prior_321_backwardcompatibility": false,
-        "type_sam": "mobile_sam"
+        "output_nc": 3
     },
     "train": {
         "sem": {
@@ -241,34 +217,32 @@
             "out_mask": false
         },
         "D_accuracy_every": 1000,
-        "D_lr": 0.0001,
+        "D_lr": 0.0002,
         "G_ema": true,
         "G_ema_beta": 0.999,
         "G_lr": 0.0001,
-        "batch_size": 32,
+        "batch_size": 4,
+	"iter_size": 16,
         "beta1": 0.9,
         "beta2": 0.999,
         "cls_l1_regression": false,
         "cls_regression": false,
         "compute_D_accuracy": false,
+        "compute_metrics": false,
         "compute_metrics_test": false,
         "continue": false,
         "epoch": "latest",
         "epoch_count": 1,
         "export_jit": false,
-        "feat_wavelet": false,
         "gan_mode": "lsgan",
-        "iter_size": 1,
+        "iter_size": 16,
         "load_iter": 0,
         "lr_decay_iters": 50,
         "lr_policy": "linear",
         "metrics_every": 1000,
-        "metrics_list": [
-            "FID"
-        ],
         "mm_lambda_z": 0.5,
         "mm_nz": 8,
-        "n_epochs": 100,
+        "n_epochs": 400,
         "n_epochs_decay": 100,
         "nb_img_max_fid": 1000000000,
         "optim": "adamw",
@@ -303,12 +277,12 @@
         "no_flip": false,
         "no_rotate": true
     },
-    "checkpoints_dir": "checkpoints",
-    "dataroot": "datasets/mapillary_full",
+    "checkpoints_dir": "./checkpoints/",
+    "dataroot": "noglasses2glasses_ffhq",
     "ddp_port": "12355",
     "gpu_ids": "0",
-    "model_type": "palette",
-    "name": "mapillary",
+    "model_type": "cm",
+    "name": "noglasses2glasses",
     "phase": "train",
     "suffix": "",
     "test_batch_size": 1,

--- a/examples/example_ddpm_SEN2VEN.json
+++ b/examples/example_ddpm_SEN2VEN.json
@@ -68,21 +68,24 @@
             "nuplet_size": 3,
             "projection_threshold": 1.0
         },
-        "palette": {
+	"palette": {
+	    "loss": "MSE",
+	    "sampling_method": "ddpm"
+	},
+        "diffusion": {
             "computed_sketch_list": [
                 "canny",
                 "hed"
             ],
             "cond_embed_dim": 32,
             "cond_image_creation": "y_t",
-            "conditioning": "",
+            "cond_embed": "",
             "ddim_eta": 0.5,
             "ddim_num_steps": 10,
             "dropout_prob": 0.0,
             "generate_per_class": false,
             "inference_num": -1,
             "lambda_G": 1.0,
-            "loss": "MSE",
             "prob_use_previous_frame": 0.5,
             "ref_embed_net": "clip",
             "sam_crop_delta": true,
@@ -96,7 +99,6 @@
             "sam_redundancy_threshold": 0.62,
             "sam_sobel_threshold": 0.7,
             "sam_use_gaussian_filter": false,
-            "sampling_method": "ddpm",
             "sketch_canny_range": [
                 0,
                 765

--- a/examples/example_ddpm_mario.json
+++ b/examples/example_ddpm_mario.json
@@ -69,21 +69,24 @@
             "nuplet_size": 3,
             "projection_threshold": 1.0
         },
-        "palette": {
+	"palette": {
+	    "loss": "MSE",
+	    "sampling_method": "ddpm"
+	},
+        "diffusion": {
             "computed_sketch_list": [
                 "canny",
                 "hed"
             ],
             "cond_embed_dim": 32,
             "cond_image_creation": "y_t",
-            "conditioning": "class",
+            "cond_embed": "class",
             "ddim_eta": 0.5,
             "ddim_num_steps": 10,
             "dropout_prob": 0.0,
             "generate_per_class": true,
             "inference_num": -1,
             "lambda_G": 1.0,
-            "loss": "MSE",
             "prob_use_previous_frame": 0.5,
             "ref_embed_net": "clip",
             "sam_crop_delta": true,
@@ -97,7 +100,6 @@
             "sam_redundancy_threshold": 0.62,
             "sam_sobel_threshold": 0.7,
             "sam_use_gaussian_filter": false,
-            "sampling_method": "ddpm",
             "sketch_canny_range": [
                 0,
                 765

--- a/examples/example_ddpm_noglasses2glasses.json
+++ b/examples/example_ddpm_noglasses2glasses.json
@@ -72,18 +72,21 @@
             "nuplet_size": 3,
             "projection_threshold": 1.0
         },
-        "palette": {
+	"palette": {
+	    "loss": "MSE",
+	    "sampling_method": "ddpm"
+	},
+        "diffusion": {
             "computed_sketch_list": [
                 "canny",
                 "hed"
             ],
             "cond_embed_dim": 32,
             "cond_image_creation": "y_t",
-            "conditioning": "",
+            "cond_embed": "",
             "generate_per_class": false,
             "inference_num": -1,
             "lambda_G": 1.0,
-            "loss": "MSE",
             "prob_use_previous_frame": 0.5,
             "sam_crop_delta": true,
             "sam_final_canny": false,
@@ -96,7 +99,6 @@
             "sam_redundancy_threshold": 0.62,
             "sam_sobel_threshold": 0.7,
             "sam_use_gaussian_filter": false,
-            "sampling_method": "ddpm",
             "sketch_canny_range": [
                 0,
                 765

--- a/examples/example_ddpm_unetref_viton.json
+++ b/examples/example_ddpm_unetref_viton.json
@@ -69,21 +69,24 @@
             "nuplet_size": 3,
             "projection_threshold": 1.0
         },
-        "palette": {
+	"palette": {
+	    "loss": "MSE",
+	    "sampling_method": "ddpm"
+	},
+        "diffusion": {
             "computed_sketch_list": [
                 "canny",
                 "hed"
             ],
             "cond_embed_dim": 32,
             "cond_image_creation": "y_t",
-            "conditioning": "",
+            "cond_embed": "",
             "ddim_eta": 0.5,
             "ddim_num_steps": 10,
             "dropout_prob": 0.0,
             "generate_per_class": true,
             "inference_num": 10,
             "lambda_G": 1.0,
-            "loss": "MSE",
             "prob_use_previous_frame": 0.5,
             "ref_embed_net": "clip",
             "sam_crop_delta": true,
@@ -97,7 +100,6 @@
             "sam_redundancy_threshold": 0.62,
             "sam_sobel_threshold": 0.7,
             "sam_use_gaussian_filter": false,
-            "sampling_method": "ddpm",
             "sketch_canny_range": [
                 0,
                 765

--- a/examples/example_ddpm_viton_tutorial.json
+++ b/examples/example_ddpm_viton_tutorial.json
@@ -69,15 +69,18 @@
             "nuplet_size": 3,
             "projection_threshold": 1.0
         },
-        "palette": {
+	"palette": {
+	    "loss": "MSE",
+	    "sampling_method": "ddpm",
+	},
+        "diffusion": {
             "computed_sketch_list": [
                 "canny",
                 "hed"
             ],
             "cond_embed_dim": 32,
             "cond_image_creation": "y_t",
-            "conditioning": "",
-            "dropout_prob": 0.0,
+            "cond_embed": "",
             "generate_per_class": false,
             "inference_num": -1,
             "lambda_G": 1.0,

--- a/models/cm_model.py
+++ b/models/cm_model.py
@@ -1,0 +1,268 @@
+import copy
+import itertools
+import math
+import random
+import warnings
+
+import torch
+import torchvision.transforms as T
+import tqdm
+from torch import nn
+
+from util.network_group import NetworkGroup
+from util.iter_calculator import IterCalculator
+
+from util.mask_generation import random_edge_mask
+
+from . import diffusion_networks
+from .base_diffusion_model import BaseDiffusionModel
+
+
+def pseudo_huber_loss(input, target):
+    """Computes the pseudo huber loss.
+
+    Parameters
+    ----------
+    input : Tensor
+        Input tensor.
+    target : Tensor
+        Target tensor.
+
+    Returns
+    -------
+    Tensor
+        Pseudo huber loss.
+    """
+    c = 0.00054 * math.sqrt(math.prod(input.shape[1:]))
+    return torch.sqrt((input - target) ** 2 + c**2) - c
+
+
+class CMModel(BaseDiffusionModel):
+    @staticmethod
+    def modify_commandline_options(parser, is_train=True):
+        """Configures options specific to the consistency model"""
+        parser = BaseDiffusionModel.modify_commandline_options(
+            parser, is_train=is_train
+        )
+
+        parser.add_argument(
+            "--alg_cm_num_steps",
+            type=int,
+            default=1000000,
+            help="number of steps before reaching the fully discretized consistency model sampling schedule",
+        )
+
+        if is_train:
+            parser = CMModel.modify_commandline_options_train(parser)
+
+        return parser
+
+    @staticmethod
+    def modify_commandline_options_train(parser):
+        parser = BaseDiffusionModel.modify_commandline_options_train(parser)
+        return parser
+
+    def after_parse(opt):
+        return opt
+
+    def __init__(self, opt, rank):
+        super().__init__(opt, rank)
+
+        if opt.isTrain:
+            batch_size = self.opt.train_batch_size
+        else:
+            batch_size = self.opt.test_batch_size
+        self.inference_num = batch_size
+
+        self.total_t = self.opt.alg_cm_num_steps
+
+        # Visuals
+        visual_outputs = []
+        self.gen_visual_names = [
+            "gt_image_",
+            "y_t_",
+            "output_",
+            "next_noisy_x_",
+            "current_noisy_x_",
+        ]
+
+        if opt.alg_diffusion_cond_image_creation != "y_t":
+            self.gen_visual_names.append("cond_image_")
+        if self.opt.alg_diffusion_cond_image_creation == "previous_frame":
+            self.gen_visual_names.insert(0, "previous_frame_")
+
+        for k in range(self.inference_num):
+            self.visual_names.append([temp + str(k) for temp in self.gen_visual_names])
+        self.visual_names.append(visual_outputs)
+
+        # Define network
+        opt.alg_palette_sampling_method = ""
+        opt.alg_diffusion_cond_embed = opt.alg_diffusion_cond_image_creation
+        opt.alg_diffusion_cond_embed_dim = 256
+        self.netG_A = diffusion_networks.define_G(**vars(opt))
+
+        self.model_names = ["G_A"]
+
+        self.model_names_export = ["G_A"]
+
+        G_models = ["G_A"]
+        G_parameters = [self.netG_A.parameters()]
+        G_parameters = itertools.chain(*G_parameters)
+
+        # Define optimizer
+        if opt.isTrain:
+            self.optimizer_G = opt.optim(
+                opt,
+                G_parameters,
+                lr=opt.train_G_lr,
+                betas=(opt.train_beta1, opt.train_beta2),
+                weight_decay=opt.train_optim_weight_decay,
+                eps=opt.train_optim_eps,
+            )
+            self.optimizers.append(self.optimizer_G)
+
+        self.loss_names_G = ["G_tot"]
+        self.loss_names = self.loss_names_G
+
+        # Make group
+        self.networks_groups = []
+
+        losses_backward = ["loss_G_tot"]
+
+        self.group_G = NetworkGroup(
+            networks_to_optimize=G_models,
+            forward_functions=[],
+            backward_functions=["compute_cm_loss"],
+            loss_names_list=["loss_names_G"],
+            optimizer=["optimizer_G"],
+            loss_backward=losses_backward,
+            networks_to_ema=G_models,
+        )
+        self.networks_groups.append(self.group_G)
+
+        losses_G = []
+        self.loss_names_G += losses_G
+        self.loss_names = self.loss_names_G.copy()
+
+        # Itercalculator
+        self.iter_calculator_init()
+
+    def set_input(self, data):
+
+        if (
+            len(data["A"].to(self.device).shape) == 5
+        ):  # we're using temporal successive frames
+            self.previous_frame = data["A"].to(self.device)[:, 0]
+            self.y_t = data["A"].to(self.device)[:, 1]
+            self.gt_image = data["B"].to(self.device)[:, 1]
+            self.previous_frame_mask = data["B_label_mask"].to(self.device)[:, 0]
+            self.mask = data["B_label_mask"].to(self.device)[:, 1]
+        else:
+            # inpainting only
+            self.y_t = data["A"].to(self.device)
+            self.gt_image = data["B"].to(self.device)
+            self.mask = data["B_label_mask"].to(self.device)
+
+        if self.opt.alg_diffusion_cond_image_creation == "previous_frame":
+            cond_image_list = []
+            for cur_frame, cur_mask in zip(
+                self.previous_frame.cpu(),
+                self.previous_frame_mask.cpu(),
+            ):
+                if (
+                    random.random()
+                    < self.opt.alg_diffusion_cond_prob_use_previous_frame
+                ):
+                    cond_image_list.append(cur_frame.to(self.device))
+                else:
+                    cond_image_list.append(
+                        -1 * torch.ones_like(cur_frame, device=self.device)
+                    )
+
+                self.cond_image = torch.stack(cond_image_list)
+                self.cond_image = self.cond_image.to(self.device)
+        elif self.opt.alg_diffusion_cond_image_creation == "computed_sketch":
+            fill_img_with_random_sketch = random_edge_mask(
+                fn_list=self.opt.alg_diffusion_computed_sketch_list
+            )
+            if "canny" in fill_img_with_random_sketch.__name__:
+                low = min(self.opt.alg_diffusion_sketch_canny_range)
+                high = max(self.opt.alg_diffusion_sketch_canny_range)
+                self.cond_image = fill_img_with_random_sketch(
+                    self.gt_image,
+                    self.mask,
+                    low_threshold_random=low,
+                    high_threshold_random=high,
+                )
+        else:  # y_t
+            self.cond_image = None  # self.y_t
+
+        self.batch_size = self.y_t.shape[0]
+
+        self.real_A = self.y_t
+        self.real_B = self.gt_image
+
+    def compute_cm_loss(self):
+
+        y_0 = self.gt_image  # ground truth
+        y_cond = self.cond_image  # conditioning
+        mask = self.mask
+        (
+            pred_x,
+            target_x,
+            num_timesteps,
+            sigmas,
+            loss_weights,
+            self.next_noisy_x,
+            self.current_noisy_x,
+        ) = self.netG_A(y_0, self.total_t, mask, y_cond)
+
+        mask_pred_x = mask * pred_x
+        mask_target_x = mask * target_x
+        loss = (pseudo_huber_loss(mask_pred_x, mask_target_x) * loss_weights).mean()
+
+        self.loss_G_tot = loss * self.opt.alg_diffusion_lambda_G
+
+    def inference(self):
+
+        if hasattr(self.netG_A, "module"):
+            netG = self.netG_A.module
+        else:
+            netG = self.netG_A
+
+        if len(self.opt.gpu_ids) > 1 and self.opt.G_unet_mha_norm_layer == "batchnorm":
+            netG = revert_sync_batchnorm(netG)
+
+        # XXX: inpainting only for now
+
+        if self.mask is not None:
+            mask = self.mask[: self.inference_num]
+        else:
+            mask = self.mask
+
+        # restoration call
+        sampling_sigmas = (80.0, 24.4, 5.84, 0.9, 0.661)
+        if not self.cond_image is None:
+            y_cond = self.cond_image[: self.inference_num]
+        else:
+            y_cond = None
+        self.output = netG.restoration(
+            self.y_t[: self.inference_num], y_cond, sampling_sigmas, mask
+        )
+        self.fake_B = self.output
+        self.visuals = self.output
+
+        # set visual names
+        for name in self.gen_visual_names:
+            whole_tensor = getattr(self, name[:-1])
+            for k in range(min(self.inference_num, self.get_current_batch_size())):
+                cur_name = name + str(k)
+                cur_tensor = whole_tensor[k : k + 1]
+                if "mask" in name:
+                    cur_tensor = cur_tensor.squeeze(0)
+                setattr(self, cur_name, cur_tensor)
+
+    def compute_visuals(self):
+        super().compute_visuals()
+        with torch.no_grad():
+            self.inference()

--- a/models/modules/cm_generator.py
+++ b/models/modules/cm_generator.py
@@ -1,0 +1,397 @@
+import math
+import sys
+import torch
+from inspect import isfunction
+from functools import partial
+import numpy as np
+from torch import nn, Tensor
+from einops.layers.torch import Rearrange
+
+# from models.modules.diffusion_utils import gamma_embedding
+
+
+def pad_dims_like(x: Tensor, other: Tensor) -> Tensor:
+    """Pad dimensions of tensor `x` to match the shape of tensor `other`.
+
+    Parameters
+    ----------
+    x : Tensor
+        Tensor to be padded.
+    other : Tensor
+        Tensor whose shape will be used as reference for padding.
+
+    Returns
+    -------
+    Tensor
+        Padded tensor with the same shape as other.
+    """
+    ndim = other.ndim - x.ndim
+    return x.view(*x.shape, *((1,) * ndim))
+
+
+def improved_timesteps_schedule(
+    current_training_step: int,
+    total_training_steps: int,
+    initial_timesteps: int = 10,
+    final_timesteps: int = 1280,
+) -> int:
+    """Implements the improved timestep discretization schedule.
+
+    Parameters
+    ----------
+    current_training_step : int
+        Current step in the training loop.
+    total_training_steps : int
+        Total number of steps the model will be trained for.
+    initial_timesteps : int, default=2
+        Timesteps at the start of training.
+    final_timesteps : int, default=150
+        Timesteps at the end of training.
+
+    Returns
+    -------
+    int
+        Number of timesteps at the current point in training.
+
+    References
+    ----------
+    [1] [Improved Techniques For Consistency Training](https://arxiv.org/pdf/2310.14189.pdf)
+    """
+    total_training_steps_prime = math.floor(
+        total_training_steps
+        / (math.log2(math.floor(final_timesteps / initial_timesteps)) + 1)
+    )
+    num_timesteps = initial_timesteps * math.pow(
+        2, math.floor(current_training_step / total_training_steps_prime)
+    )
+    num_timesteps = min(num_timesteps, final_timesteps) + 1
+
+    return num_timesteps
+
+
+def karras_schedule(
+    num_timesteps: int,
+    sigma_min: float = 0.002,
+    sigma_max: float = 80.0,
+    rho: float = 7.0,
+    device: torch.device = None,
+) -> Tensor:
+    """Implements the karras schedule that controls the standard deviation of
+    noise added.
+
+    Parameters
+    ----------
+    num_timesteps : int
+        Number of timesteps at the current point in training.
+    sigma_min : float, default=0.002
+        Minimum standard deviation.
+    sigma_max : float, default=80.0
+        Maximum standard deviation
+    rho : float, default=7.0
+        Schedule hyper-parameter.
+    device : torch.device, default=None
+        Device to generate the schedule/sigmas/boundaries/ts on.
+
+    Returns
+    -------
+    Tensor
+        Generated schedule/sigmas/boundaries/ts.
+    """
+    rho_inv = 1.0 / rho
+    # Clamp steps to 1 so that we don't get nans
+    steps = torch.arange(num_timesteps, device=device) / max(num_timesteps - 1, 1)
+    sigmas = sigma_min**rho_inv + steps * (
+        sigma_max**rho_inv - sigma_min**rho_inv
+    )
+    sigmas = sigmas**rho
+
+    return sigmas
+
+
+def lognormal_timestep_distribution(
+    num_samples: int,
+    sigmas: Tensor,
+    mean: float = -1.1,
+    std: float = 2.0,
+) -> Tensor:
+    """Draws timesteps from a lognormal distribution.
+
+    Parameters
+    ----------
+    num_samples : int
+        Number of samples to draw.
+    sigmas : Tensor
+        Standard deviations of the noise.
+    mean : float, default=-1.1
+        Mean of the lognormal distribution.
+    std : float, default=2.0
+        Standard deviation of the lognormal distribution.
+
+    Returns
+    -------
+    Tensor
+        Timesteps drawn from the lognormal distribution.
+
+    References
+    ----------
+    [1] [Improved Techniques For Consistency Training](https://arxiv.org/pdf/2310.14189.pdf)
+    """
+    pdf = torch.erf((torch.log(sigmas[1:]) - mean) / (std * math.sqrt(2))) - torch.erf(
+        (torch.log(sigmas[:-1]) - mean) / (std * math.sqrt(2))
+    )
+    pdf = pdf / pdf.sum()
+
+    timesteps = torch.multinomial(pdf, num_samples, replacement=True)
+
+    return timesteps
+
+
+def improved_loss_weighting(sigmas: Tensor) -> Tensor:
+    """Computes the weighting for the consistency loss.
+
+    Parameters
+    ----------
+    sigmas : Tensor
+        Standard deviations of the noise.
+
+    Returns
+    -------
+    Tensor
+        Weighting for the consistency loss.
+
+    References
+    ----------
+    [1] [Improved Techniques For Consistency Training](https://arxiv.org/pdf/2310.14189.pdf)
+    """
+    return 1 / (sigmas[1:] - sigmas[:-1])
+
+
+def output_scaling(
+    sigma: Tensor, sigma_data: float = 0.5, sigma_min: float = 0.002
+) -> Tensor:
+    """Computes the scaling value for the model's output.
+
+    Parameters
+    ----------
+    sigma : Tensor
+        Current standard deviation of the noise.
+    sigma_data : float, default=0.5
+        Standard deviation of the data.
+    sigma_min : float, default=0.002
+        Minimum standard deviation of the noise from the karras schedule.
+
+    Returns
+    -------
+    Tensor
+        Scaling value for the model's output.
+    """
+    return (sigma_data * (sigma - sigma_min)) / (sigma_data**2 + sigma**2) ** 0.5
+
+
+def skip_scaling(
+    sigma: Tensor, sigma_data: float = 0.5, sigma_min: float = 0.002
+) -> Tensor:
+    """Computes the scaling value for the residual connection.
+
+    Parameters
+    ----------
+    sigma : Tensor
+        Current standard deviation of the noise.
+    sigma_data : float, default=0.5
+        Standard deviation of the data.
+    sigma_min : float, default=0.002
+        Minimum standard deviation of the noise from the karras schedule.
+
+    Returns
+    -------
+    Tensor
+        Scaling value for the residual connection.
+    """
+    return sigma_data**2 / ((sigma - sigma_min) ** 2 + sigma_data**2)
+
+
+class NoiseLevelEmbedding(nn.Module):
+    def __init__(self, channels: int, scale: float = 0.02) -> None:
+        super().__init__()
+
+        self.W = nn.Parameter(torch.randn(channels // 2) * scale, requires_grad=False)
+
+        self.projection = nn.Sequential(
+            nn.Linear(channels, 4 * channels),
+            nn.SiLU(),
+            nn.Linear(4 * channels, channels),
+            Rearrange("b c -> b c () ()"),
+        )
+
+    def forward(self, x: Tensor) -> Tensor:
+        h = x[:, None] * self.W[None, :] * 2 * torch.pi
+        h = torch.cat([torch.sin(h), torch.cos(h)], dim=-1)
+
+        return self.projection(h)
+
+
+class CMGenerator(nn.Module):
+    def __init__(
+        self,
+        cm_model,
+        sampling_method,
+        image_size,
+        G_ngf,
+    ):
+        super().__init__()
+
+        self.cm_model = cm_model
+        self.sampling_method = sampling_method
+        self.image_size = image_size
+
+        self.sigma_min = 0.002
+        self.sigma_max = 80.0
+        self.sigma_data = 0.5
+
+        # improved consistency training
+        self.rho = 7.0
+        self.initial_timesteps = 10
+        self.final_timesteps = 1280
+        self.lognormal_mean = -1.1
+        self.lognormal_std = 2.0
+
+        self.cond_embed_dim = self.cm_model.cond_embed_dim
+        self.cm_cond_embed = NoiseLevelEmbedding(self.cond_embed_dim)
+
+        self.current_t = 2
+
+    def cm_forward(self, x, sigma, sigma_data, sigma_min, x_cond=None):
+        c_skip = skip_scaling(sigma, sigma_data, sigma_min)
+        c_out = output_scaling(sigma, sigma_data, sigma_min)
+
+        # Pad dimensions as broadcasting will not work
+        c_skip = pad_dims_like(c_skip, x)
+        c_out = pad_dims_like(c_out, x)
+
+        embed_noise_level = self.embed_sigmas(sigma)
+        if not x_cond is None:
+            x_with_cond = torch.cat([x_cond, x], dim=1)
+        else:
+            x_with_cond = x
+        return c_skip * x + c_out * self.cm_model(
+            x_with_cond, embed_noise_level
+        )  # , **kwargs)
+
+    def forward(
+        self,
+        x,
+        total_training_steps=50000,
+        mask=None,
+        x_cond=None,
+    ):
+
+        num_timesteps = improved_timesteps_schedule(
+            self.current_t,
+            total_training_steps,
+            self.initial_timesteps,
+            self.final_timesteps,
+        )
+        sigmas = karras_schedule(
+            num_timesteps, self.sigma_min, self.sigma_max, self.rho, x.device
+        )
+        noise = torch.randn_like(x)
+
+        timesteps = lognormal_timestep_distribution(
+            x.shape[0], sigmas, self.lognormal_mean, self.lognormal_std
+        )
+
+        current_sigmas = sigmas[timesteps]
+        next_sigmas = sigmas[timesteps + 1]
+
+        if mask is not None:
+            mask = torch.clamp(mask, min=0.0, max=1.0)
+
+        next_noisy_x = x + pad_dims_like(next_sigmas, x) * noise
+        next_noisy_x = next_noisy_x * mask + (1 - mask) * x
+
+        next_x = self.cm_forward(
+            next_noisy_x,
+            next_sigmas,
+            self.sigma_data,
+            self.sigma_min,
+            x_cond,
+        )
+
+        with torch.no_grad():
+            current_noisy_x = x + pad_dims_like(current_sigmas, x) * noise
+            current_noisy_x = current_noisy_x * mask + (1 - mask) * x
+
+            current_x = self.cm_forward(
+                current_noisy_x,
+                current_sigmas,
+                self.sigma_data,
+                self.sigma_min,
+                x_cond,
+            )
+
+        loss_weights = pad_dims_like(improved_loss_weighting(sigmas)[timesteps], next_x)
+
+        self.current_t += 1
+
+        return (
+            next_x,
+            current_x,
+            num_timesteps,
+            sigmas,
+            loss_weights,
+            next_noisy_x,
+            current_noisy_x,
+        )
+
+    def restoration(self, y, y_cond, sigmas, mask, clip_denoised=True):
+
+        if mask is not None:
+            mask = torch.clamp(
+                mask, min=0.0, max=1.0
+            )  # removes class information from mask
+        y = y * (1 - mask)
+
+        # Sample at the end of the schedule
+        x = y + sigmas[0] * torch.randn_like(y)
+
+        x = x * mask + (1 - mask) * y
+
+        sigma = torch.full((x.shape[0],), sigmas[0], dtype=x.dtype, device=x.device)
+        x = self.cm_forward(
+            x,
+            sigma,
+            self.sigma_data,
+            self.sigma_min,
+            y_cond,
+        )
+        if clip_denoised:
+            x = x.clamp(min=-1.0, max=1.0)
+
+        x = x * mask + (1 - mask) * y
+
+        for sigma in sigmas[1:]:
+
+            sigma = torch.full((x.shape[0],), sigma, dtype=x.dtype, device=x.device)
+            x = x + pad_dims_like(
+                (sigma**2 - self.sigma_min**2) ** 0.5, x
+            ) * torch.randn_like(x)
+
+            x = x * mask + (1 - mask) * y
+
+            x = self.cm_forward(
+                x,
+                sigma,
+                self.sigma_data,
+                self.sigma_min,
+                y_cond,
+            )
+
+            if clip_denoised:
+                x = x.clamp(min=-1.0, max=1.0)
+            x = x * mask + (1 - mask) * y
+
+        return x
+
+    def embed_sigmas(self, sigmas):
+        emb = self.cm_cond_embed(sigmas).squeeze(dim=[2, 3])
+        return emb

--- a/models/modules/diffusion_utils.py
+++ b/models/modules/diffusion_utils.py
@@ -28,6 +28,7 @@ def gamma_embedding_1D(gammas, dim, max_period):
 
 
 def gamma_embedding(gammas, dim, max_period=10000):
+
     return_list = []
     reduced_dim = dim // gammas.shape[1]
 

--- a/models/modules/unet_generator_attn/unet_generator_attn.py
+++ b/models/modules/unet_generator_attn/unet_generator_attn.py
@@ -455,6 +455,7 @@ class UNet(nn.Module):
         self.res_blocks = res_blocks
         self.attn_res = attn_res
         self.dropout = dropout
+        self.zero_dropout = 0.0
         self.channel_mults = channel_mults
         self.conv_resample = conv_resample
         self.use_checkpoint = use_checkpoint
@@ -490,7 +491,7 @@ class UNet(nn.Module):
                     ResBlock(
                         ch,
                         self.cond_embed_dim,
-                        dropout,
+                        self.zero_dropout,
                         out_channel=int(mult * self.inner_channel),
                         use_checkpoint=use_checkpoint,
                         use_scale_shift_norm=use_scale_shift_norm,
@@ -520,7 +521,7 @@ class UNet(nn.Module):
                         ResBlock(
                             ch,
                             self.cond_embed_dim,
-                            dropout,
+                            self.zero_dropout,
                             out_channel=out_ch,
                             use_checkpoint=use_checkpoint,
                             use_scale_shift_norm=use_scale_shift_norm,
@@ -582,7 +583,7 @@ class UNet(nn.Module):
                     ResBlock(
                         ch + ich,
                         self.cond_embed_dim,
-                        dropout,
+                        self.zero_dropout,
                         out_channel=int(self.inner_channel * mult),
                         use_checkpoint=use_checkpoint,
                         use_scale_shift_norm=use_scale_shift_norm,
@@ -608,7 +609,7 @@ class UNet(nn.Module):
                         ResBlock(
                             ch,
                             self.cond_embed_dim,
-                            dropout,
+                            self.zero_dropout,
                             out_channel=out_ch,
                             use_checkpoint=use_checkpoint,
                             use_scale_shift_norm=use_scale_shift_norm,

--- a/models/palette_model.py
+++ b/models/palette_model.py
@@ -6,7 +6,6 @@ import warnings
 
 import torch
 import torchvision.transforms as T
-import tqdm
 from torch import nn
 
 from data.online_creation import fill_mask_with_color, fill_mask_with_random
@@ -53,20 +52,6 @@ class PaletteModel(BaseDiffusionModel):
         parser = BaseDiffusionModel.modify_commandline_options_train(parser)
 
         parser.add_argument(
-            "--alg_palette_task",
-            default="inpainting",
-            choices=["inpainting", "super_resolution", "pix2pix"],
-            help="Whether to perform inpainting, super resolution or pix2pix",
-        )
-
-        parser.add_argument(
-            "--alg_palette_lambda_G",
-            type=float,
-            default=1.0,
-            help="weight for supervised loss",
-        )
-
-        parser.add_argument(
             "--alg_palette_loss",
             type=str,
             default="MSE",
@@ -75,141 +60,6 @@ class PaletteModel(BaseDiffusionModel):
         )
 
         parser.add_argument(
-            "--alg_palette_inference_num",
-            type=int,
-            default=-1,
-            help="nb of examples processed for inference",
-        )
-
-        parser.add_argument(
-            "--alg_palette_dropout_prob",
-            type=float,
-            default=0.0,
-            help="dropout probability for classifier-free guidance",
-        )
-
-        parser.add_argument(
-            "--alg_palette_cond_image_creation",
-            type=str,
-            default="y_t",
-            choices=[
-                "y_t",
-                "previous_frame",
-                "computed_sketch",
-                "low_res",
-                "ref",
-            ],
-            help="how image conditioning is created: either from y_t (no conditioning), previous frame, from computed sketch (e.g. canny), from low res image or from reference image (i.e. image that is not aligned with the ground truth)",
-        )
-
-        parser.add_argument(
-            "--alg_palette_computed_sketch_list",
-            nargs="+",
-            type=str,
-            default=["canny", "hed"],
-            help="what primitives to use for random sketch",
-            choices=["sketch", "canny", "depth", "hed", "hough", "sam"],
-        )
-
-        parser.add_argument(
-            "--alg_palette_sketch_canny_range",
-            type=int,
-            nargs="+",
-            default=[0, 255 * 3],
-            help="range of randomized canny sketch thresholds",
-        )
-
-        parser.add_argument(
-            "--alg_palette_super_resolution_scale",
-            type=float,
-            default=2.0,
-            help="scale for super resolution",
-        )
-
-        parser.add_argument(
-            "--alg_palette_sam_use_gaussian_filter",
-            action="store_true",
-            default=False,
-            help="whether to apply a Gaussian blur to each SAM masks",
-        )
-
-        parser.add_argument(
-            "--alg_palette_sam_no_sobel_filter",
-            action="store_false",
-            default=True,
-            help="whether to not use a Sobel filter on each SAM masks",
-        )
-
-        parser.add_argument(
-            "--alg_palette_sam_no_output_binary_sam",
-            action="store_false",
-            default=True,
-            help="whether to not output binary sketch before Canny",
-        )
-
-        parser.add_argument(
-            "--alg_palette_sam_redundancy_threshold",
-            type=float,
-            default=0.62,
-            help="redundancy threshold above which redundant masks are not kept",
-        )
-
-        parser.add_argument(
-            "--alg_palette_sam_sobel_threshold",
-            type=float,
-            default=0.7,
-            help="sobel threshold in %% of gradient magnitude",
-        )
-
-        parser.add_argument(
-            "--alg_palette_sam_final_canny",
-            action="store_true",
-            default=False,
-            help="whether to perform a Canny edge detection on sam sketch to soften the edges",
-        )
-
-        parser.add_argument(
-            "--alg_palette_sam_min_mask_area",
-            type=float,
-            default=0.001,
-            help="minimum area in proportion of image size for a mask to be kept",
-        )
-
-        parser.add_argument(
-            "--alg_palette_sam_max_mask_area",
-            type=float,
-            default=0.99,
-            help="maximum area in proportion of image size for a mask to be kept",
-        )
-
-        parser.add_argument(
-            "--alg_palette_sam_points_per_side",
-            type=int,
-            default=16,
-            help="number of points per side of image to prompt SAM with (# of prompted points will be points_per_side**2)",
-        )
-
-        parser.add_argument(
-            "--alg_palette_sam_no_sample_points_in_ellipse",
-            action="store_false",
-            default=True,
-            help="whether to not sample the points inside an ellipse to avoid the corners of the image",
-        )
-
-        parser.add_argument(
-            "--alg_palette_sam_crop_delta",
-            type=int,
-            default=True,
-            help="extend crop's width and height by 2*crop_delta before computing masks",
-        )
-
-        parser.add_argument(
-            "--alg_palette_prob_use_previous_frame",
-            type=float,
-            default=0.5,
-            help="prob to use previous frame as y cond",
-        )
-        parser.add_argument(
             "--alg_palette_sampling_method",
             type=str,
             default="ddpm",
@@ -217,40 +67,11 @@ class PaletteModel(BaseDiffusionModel):
             help="choose the sampling method between ddpm and ddim",
         )
 
-        parser.add_argument(
-            "--alg_palette_conditioning",
-            type=str,
-            default="",
-            choices=["", "mask", "class", "mask_and_class", "ref"],
-            help="whether to use conditioning or not",
-        )
-
-        parser.add_argument(
-            "--alg_palette_cond_embed_dim",
-            type=int,
-            default=32,
-            help="nb of examples processed for inference",
-        )
-
-        parser.add_argument(
-            "--alg_palette_generate_per_class",
-            action="store_true",
-            help="whether to generate samples of each images",
-        )
-
-        parser.add_argument(
-            "--alg_palette_ref_embed_net",
-            type=str,
-            default="clip",
-            choices=["clip", "imagebind"],
-            help="embedding network to use for ref conditioning",
-        )
-
         return parser
 
     @staticmethod
     def after_parse(opt):
-        if opt.isTrain and opt.alg_palette_dropout_prob > 0:
+        if opt.isTrain and opt.alg_diffusion_dropout_prob > 0:
             # we add a class to be the unconditionned one.
             opt.f_s_semantic_nclasses += 1
             opt.cls_semantic_nclasses += 1
@@ -259,11 +80,11 @@ class PaletteModel(BaseDiffusionModel):
     def __init__(self, opt, rank):
         super().__init__(opt, rank)
 
-        self.task = self.opt.alg_palette_task
+        self.task = self.opt.alg_diffusion_task
         if self.task == "super_resolution":
-            self.opt.alg_palette_cond_image_creation = "low_res"
+            self.opt.alg_diffusion_cond_image_creation = "low_res"
             self.data_crop_size_low_res = int(
-                self.opt.data_crop_size / self.opt.alg_palette_super_resolution_scale
+                self.opt.data_crop_size / self.opt.alg_diffusion_super_resolution_scale
             )
             self.transform_lr = T.Resize(
                 (self.data_crop_size_low_res, self.data_crop_size_low_res)
@@ -276,18 +97,18 @@ class PaletteModel(BaseDiffusionModel):
             batch_size = self.opt.train_batch_size
         else:
             batch_size = self.opt.test_batch_size
-        if self.opt.alg_palette_inference_num == -1:
+        if self.opt.alg_diffusion_inference_num == -1:
             self.inference_num = batch_size
         else:
-            self.inference_num = min(self.opt.alg_palette_inference_num, batch_size)
+            self.inference_num = min(self.opt.alg_diffusion_inference_num, batch_size)
 
         self.num_classes = max(
             self.opt.f_s_semantic_nclasses, self.opt.cls_semantic_nclasses
         )
 
         self.use_ref = (
-            self.opt.alg_palette_cond_image_creation == "ref"
-            or "ref" in self.opt.alg_palette_conditioning
+            self.opt.alg_diffusion_cond_image_creation == "ref"
+            or "ref" in self.opt.alg_diffusion_cond_embed
             or "ref" in self.opt.G_netG
         )
 
@@ -302,8 +123,8 @@ class PaletteModel(BaseDiffusionModel):
             self.gen_visual_names.extend(["y_t_", "mask_"])
 
         if (
-            self.opt.alg_palette_conditioning != ""
-            and self.opt.alg_palette_generate_per_class
+            self.opt.alg_diffusion_cond_embed != ""
+            and self.opt.alg_diffusion_generate_per_class
             and not self.use_ref
         ):
             self.nb_classes_inference = (
@@ -321,7 +142,7 @@ class PaletteModel(BaseDiffusionModel):
         else:
             self.gen_visual_names.append("output_")
 
-        if self.opt.alg_palette_cond_image_creation == "previous_frame":
+        if self.opt.alg_diffusion_cond_image_creation == "previous_frame":
             self.gen_visual_names.insert(0, "previous_frame_")
 
         for k in range(self.inference_num):
@@ -491,16 +312,19 @@ class PaletteModel(BaseDiffusionModel):
         if self.use_ref:
             self.ref_A = data["ref_A"].to(self.device)
 
-        if self.opt.alg_palette_cond_image_creation == "y_t":
+        if self.opt.alg_diffusion_cond_image_creation == "y_t":
             self.cond_image = self.y_t
-        elif self.opt.alg_palette_cond_image_creation == "previous_frame":
+        elif self.opt.alg_diffusion_cond_image_creation == "previous_frame":
             cond_image_list = []
 
             for cur_frame, cur_mask in zip(
                 self.previous_frame.cpu(),
                 self.previous_frame_mask.cpu(),
             ):
-                if random.random() < self.opt.alg_palette_prob_use_previous_frame:
+                if (
+                    random.random()
+                    < self.opt.alg_diffusion_cond_prob_use_previous_frame
+                ):
                     cond_image_list.append(cur_frame.to(self.device))
                 else:
                     cond_image_list.append(
@@ -509,17 +333,17 @@ class PaletteModel(BaseDiffusionModel):
 
                 self.cond_image = torch.stack(cond_image_list)
                 self.cond_image = self.cond_image.to(self.device)
-        elif self.opt.alg_palette_cond_image_creation == "computed_sketch":
-            randomize_batch = False
+        elif self.opt.alg_diffusion_cond_image_creation == "computed_sketch":
+            randomize_batch = False  # XXX: unused (beniz)
             if randomize_batch:
                 cond_images = []
                 for image, mask in zip(self.gt_image, self.mask):
                     fill_img_with_random_sketch = random_edge_mask(
-                        fn_list=self.opt.alg_palette_computed_sketch_list
+                        fn_list=self.opt.alg_diffusion_cond_computed_sketch_list
                     )
                     if "canny" in fill_img_with_random_sketch.__name__:
-                        low = min(self.opt.alg_palette_sketch_canny_range)
-                        high = max(self.opt.alg_palette_sketch_canny_range)
+                        low = min(self.opt.alg_diffusion_cond_sketch_canny_range)
+                        high = max(self.opt.alg_diffusion_cond_sketch_canny_range)
                         batch_cond_image = fill_img_with_random_sketch(
                             image.unsqueeze(0),
                             mask.unsqueeze(0),
@@ -540,13 +364,13 @@ class PaletteModel(BaseDiffusionModel):
                     cond_images.append(batch_cond_image)
                 self.cond_image = torch.stack(cond_images)
                 self.cond_image = self.cond_image.to(self.device)
-            else:
+            else:  # no randomized batch
                 fill_img_with_random_sketch = random_edge_mask(
-                    fn_list=self.opt.alg_palette_computed_sketch_list
+                    fn_list=self.opt.alg_diffusion_cond_computed_sketch_list
                 )
                 if "canny" in fill_img_with_random_sketch.__name__:
-                    low = min(self.opt.alg_palette_sketch_canny_range)
-                    high = max(self.opt.alg_palette_sketch_canny_range)
+                    low = min(self.opt.alg_diffusion_cond_sketch_canny_range)
+                    high = max(self.opt.alg_diffusion_cond_sketch_canny_range)
                     self.cond_image = fill_img_with_random_sketch(
                         self.gt_image,
                         self.mask,
@@ -567,11 +391,11 @@ class PaletteModel(BaseDiffusionModel):
 
                 self.cond_image = self.cond_image.to(self.device)
 
-        elif self.opt.alg_palette_cond_image_creation == "low_res":
+        elif self.opt.alg_diffusion_cond_image_creation == "low_res":
             self.cond_image = self.transform_lr(self.gt_image)  # bilinear interpolation
             self.cond_image = self.transform_hr(self.cond_image)  # let's get it back
 
-        elif self.opt.alg_palette_cond_image_creation == "ref":
+        elif self.opt.alg_diffusion_cond_image_creation == "ref":
             self.cond_image = self.ref_A
 
         self.batch_size = self.cond_image.shape[0]
@@ -586,10 +410,10 @@ class PaletteModel(BaseDiffusionModel):
         noise = None
         cls = self.cls
 
-        if self.opt.alg_palette_dropout_prob > 0.0:
+        if self.opt.alg_diffusion_dropout_prob > 0.0:
             drop_ids = (
                 torch.rand(mask.shape[0], device=mask.device)
-                < self.opt.alg_palette_dropout_prob
+                < self.opt.alg_diffusion_dropout_prob
             )
         else:
             drop_ids = None
@@ -631,7 +455,7 @@ class PaletteModel(BaseDiffusionModel):
 
             loss = loss_tot
 
-        self.loss_G_tot = self.opt.alg_palette_lambda_G * loss
+        self.loss_G_tot = self.opt.alg_diffusion_lambda_G * loss
 
     def inference(self):
         if hasattr(self.netG_A, "module"):
@@ -645,19 +469,19 @@ class PaletteModel(BaseDiffusionModel):
         # task: inpainting
         if self.task in ["inpainting"]:
             if (
-                self.opt.alg_palette_conditioning != ""
-                and self.opt.alg_palette_generate_per_class
+                self.opt.alg_diffusion_cond_embed != ""
+                and self.opt.alg_diffusion_generate_per_class
                 and not self.use_ref
             ):
                 for i in range(self.nb_classes_inference):
-                    if "class" in self.opt.alg_palette_conditioning:
+                    if "class" in self.opt.alg_diffusion_cond_embed:
                         cur_class = torch.ones_like(self.cls)[: self.inference_num] * (
                             i + 1
                         )
                     else:
                         cur_class = None
 
-                    if "mask" in self.opt.alg_palette_conditioning:
+                    if "mask" in self.opt.alg_diffusion_cond_embed:
                         cur_mask = self.mask[: self.inference_num].clone().clamp(
                             min=0, max=1
                         ) * (i + 1)
@@ -703,7 +527,7 @@ class PaletteModel(BaseDiffusionModel):
                         self.inference_num, -1, -1, -1
                     )
 
-                    if self.opt.alg_palette_cond_image_creation == "ref":
+                    if self.opt.alg_diffusion_cond_image_creation == "ref":
                         y_cond = cur_ref
 
                     else:
@@ -814,7 +638,7 @@ class PaletteModel(BaseDiffusionModel):
 
         dummy_noise = None
 
-        if "class" in self.opt.alg_palette_conditioning:
+        if "class" in self.opt.alg_diffusion_cond_embed:
             dummy_cls = torch.ones(1, device=device, dtype=torch.int64)
         else:
             dummy_cls = None

--- a/options/common_options.py
+++ b/options/common_options.py
@@ -81,7 +81,7 @@ class CommonOptions(BaseOptions):
             "--model_type",
             type=str,
             default="cut",
-            choices=["cut", "cycle_gan", "palette"],
+            choices=["cut", "cycle_gan", "palette", "cm"],
             help="chooses which model to use.",
         )
         parser.add_argument(

--- a/options/inference_diffusion_options.py
+++ b/options/inference_diffusion_options.py
@@ -131,7 +131,7 @@ class InferenceDiffusionOptions(BaseOptions):
 
         # XXX: options that are also in palette_model
         parser.add_argument(
-            "--alg_palette_cond_image_creation",
+            "--alg_diffusion_cond_image_creation",
             type=str,
             choices=[
                 "y_t",
@@ -148,95 +148,95 @@ class InferenceDiffusionOptions(BaseOptions):
             help="how cond_image is created",
         )
         parser.add_argument(
-            "--alg_palette_guidance_scale",
+            "--alg_diffusion_guidance_scale",
             type=float,
             default=0.0,  # literature value: 0.2
             help="scale for classifier-free guidance, default is conditional DDPM only",
         )
         parser.add_argument(
-            "--alg_palette_sketch_canny_thresholds",
+            "--alg_diffusion_sketch_canny_thresholds",
             type=int,
             nargs="+",
             default=[0, 255 * 3],
             help="Canny thresholds",
         )
         parser.add_argument(
-            "--alg_palette_super_resolution_downsample",
+            "--alg_diffusion_super_resolution_downsample",
             action="store_true",
             help="whether to downsample the image for super resolution",
         )
         parser.add_argument(
-            "--alg_palette_sam_use_gaussian_filter",
+            "--alg_diffusion_sam_use_gaussian_filter",
             action="store_true",
             default=False,
             help="whether to apply a gaussian blur to each SAM masks",
         )
 
         parser.add_argument(
-            "--alg_palette_sam_no_sobel_filter",
+            "--alg_diffusion_sam_no_sobel_filter",
             action="store_false",
             default=True,
             help="whether to not use a Sobel filter on each SAM masks",
         )
 
         parser.add_argument(
-            "--alg_palette_sam_no_output_binary_sam",
+            "--alg_diffusion_sam_no_output_binary_sam",
             action="store_false",
             default=True,
             help="whether to not output binary sketch before Canny",
         )
 
         parser.add_argument(
-            "--alg_palette_sam_redundancy_threshold",
+            "--alg_diffusion_sam_redundancy_threshold",
             type=float,
             default=0.62,
             help="redundancy threshold above which redundant masks are not kept",
         )
 
         parser.add_argument(
-            "--alg_palette_sam_sobel_threshold",
+            "--alg_diffusion_sam_sobel_threshold",
             type=float,
             default=0.7,
             help="sobel threshold in %% of gradient magnitude",
         )
 
         parser.add_argument(
-            "--alg_palette_sam_final_canny",
+            "--alg_diffusion_sam_final_canny",
             action="store_true",
             default=False,
             help="whether to perform a Canny edge detection on sam sketch to soften the edges",
         )
 
         parser.add_argument(
-            "--alg_palette_sam_min_mask_area",
+            "--alg_diffusion_sam_min_mask_area",
             type=float,
             default=0.001,
             help="minimum area in proportion of image size for a mask to be kept",
         )
 
         parser.add_argument(
-            "--alg_palette_sam_max_mask_area",
+            "--alg_diffusion_sam_max_mask_area",
             type=float,
             default=0.99,
             help="maximum area in proportion of image size for a mask to be kept",
         )
 
         parser.add_argument(
-            "--alg_palette_sam_points_per_side",
+            "--alg_diffusion_sam_points_per_side",
             type=int,
             default=16,
             help="number of points per side of image to prompt SAM with (# of prompted points will be points_per_side**2)",
         )
 
         parser.add_argument(
-            "--alg_palette_sam_no_sample_points_in_ellipse",
+            "--alg_diffusion_sam_no_sample_points_in_ellipse",
             action="store_false",
             default=True,
             help="whether to not sample the points inside an ellipse to avoid the corners of the image",
         )
 
         parser.add_argument(
-            "--alg_palette_sam_crop_delta",
+            "--alg_diffusion_sam_crop_delta",
             type=int,
             default=True,
             help="extend crop's width and height by 2*crop_delta before computing masks",

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -61,6 +61,13 @@ if [ $OUT != 0 ]; then
     exit 1
 fi
 
+python3 ${current_dir}/../train.py --help alg_cm
+OUT=$?
+
+if [ $OUT != 0 ]; then
+    exit 1
+fi
+
 ####### no sem tests
 echo "Running no semantics training tests"
 URL=https://joligen.com/datasets/horse2zebra.zip
@@ -105,6 +112,14 @@ fi
 
 ###### diffusion process test
 python3 -m pytest -p no:cacheprovider -s "${current_dir}/../tests/test_run_diffusion.py" --dataroot "$TARGET_MASK_SEM_DIR"
+OUT=$?
+
+if [ $OUT != 0 ]; then
+    exit 1
+fi
+
+###### consistency model process test
+python3 -m pytest -p no:cacheprovider -s "${current_dir}/../tests/test_run_cm.py" --dataroot "$TARGET_MASK_SEM_DIR"
 OUT=$?
 
 if [ $OUT != 0 ]; then

--- a/test.py
+++ b/test.py
@@ -54,7 +54,8 @@ def launch_testing(opt, main_opt):
         model.netG_A.denoise_fn.model.beta_schedule["test"][
             "n_timestep"
         ] = main_opt.sampling_steps
-        set_new_noise_schedule(model.netG_A.denoise_fn.model, "test")
+        if main.opt.model_type == "palette":
+            set_new_noise_schedule(model.netG_A.denoise_fn.model, "test")
     if main_opt.sampling_method is not None:
         model.netG_A.set_new_sampling_method(main_opt.sampling_method)
     if main_opt.ddim_num_steps is not None:
@@ -153,7 +154,7 @@ if __name__ == "__main__":
     opt.train_metrics_list = main_opt.test_metrics_list
     opt.train_nb_img_max_fid = main_opt.test_nb_img
     opt.test_batch_size = main_opt.test_batch_size
-    opt.alg_palette_generate_per_class = False
+    opt.alg_diffusion_generate_per_class = False
 
     random.seed(main_opt.test_seed)
     torch.manual_seed(main_opt.test_seed)

--- a/tests/test_run_cm.py
+++ b/tests/test_run_cm.py
@@ -1,14 +1,15 @@
-import sys
 import os
-from itertools import product
-
 import pytest
 import torch.multiprocessing as mp
+import sys
+from itertools import product
 
 sys.path.append(sys.path[0] + "/..")
 import train
-from data import create_dataset
 from options.train_options import TrainOptions
+from data import create_dataset
+from itertools import product
+
 from scripts.gen_single_image_diffusion import InferenceDiffusionOptions, inference
 
 json_like_dict = {
@@ -16,31 +17,21 @@ json_like_dict = {
     "output_display_env": "joligen_utest",
     "output_display_id": 0,
     "gpu_ids": "0",
+    "data_dataset_mode": "self_supervised_labeled_mask",
     "data_load_size": 128,
     "data_crop_size": 128,
-    "data_online_creation_crop_size_A": 420,
-    "data_online_creation_crop_delta_A": 50,
-    "data_online_creation_mask_delta_A": [[50, 50]],
-    "data_online_creation_mask_delta_A_ratio": [[0.2, 0.2]],
-    "data_online_creation_crop_size_B": 420,
-    "data_online_creation_crop_delta_B": 50,
-    "data_online_creation_load_size_A": [1000, 2500],
-    "data_online_creation_load_size_B": [1000, 2500],
     "train_n_epochs": 1,
     "train_n_epochs_decay": 0,
     "data_max_dataset_size": 10,
     "data_relative_paths": True,
     "train_G_ema": True,
     "dataaug_no_rotate": True,
-    "G_unet_mha_inner_channel": 32,
     "G_unet_mha_num_head_channels": 16,
-    "G_unet_mha_channel_mults": [1, 2],
+    # "G_unet_mha_channel_mults": [1, 2],
+    "G_diff_n_timestep_train": 50000,
     "G_nblocks": 1,
     "G_padding_type": "reflect",
     "data_online_creation_rand_mask_A": True,
-    "train_export_jit": True,
-    "train_save_latest_freq": 10,
-    "G_diff_n_timestep_test": 10,
 }
 
 infer_options = {
@@ -49,14 +40,19 @@ infer_options = {
     "img_height": 128,
 }
 
-models_diffusion = ["palette"]
-G_netG = ["unet_mha", "uvit"]
-data_dataset_mode = ["self_supervised_labeled_mask_online", "self_supervised_temporal"]
+models_diffusion = ["cm"]
+G_netG = ["unet_mha"]
 
-product_list = product(models_diffusion, G_netG, data_dataset_mode)
+alg_diffusion_cond_embed = ["y_t"]
+
+product_list = product(
+    models_diffusion,
+    G_netG,
+    alg_diffusion_cond_embed,
+)
 
 
-def test_diffusion_online(dataroot):
+def test_semantic_mask(dataroot):
     json_like_dict["dataroot"] = dataroot
     json_like_dict["checkpoints_dir"] = "/".join(dataroot.split("/")[:-1])
 
@@ -67,18 +63,17 @@ def test_diffusion_online(dataroot):
         infer_options["img_in"] = os.path.join(json_like_dict["dataroot"], line[0])
         infer_options["mask_in"] = os.path.join(json_like_dict["dataroot"], line[1])
 
-    for model, Gtype, dataset_mode in product_list:
+    for (
+        model,
+        Gtype,
+        alg_diffusion_cond_embed,
+    ) in product_list:
+
         json_like_dict_c = json_like_dict.copy()
         json_like_dict_c["model_type"] = model
         json_like_dict_c["name"] += "_" + model
         json_like_dict_c["G_netG"] = Gtype
-
-        json_like_dict_c["data_dataset_mode"] = dataset_mode
-        if dataset_mode == "self_supervised_temporal":
-            json_like_dict_c["data_temporal_number_frames"] = 2
-            json_like_dict_c["data_temporal_frame_step"] = 1
-            json_like_dict_c["data_temporal_num_common_char"] = 3
-            json_like_dict_c["alg_diffusion_cond_image_creation"] = "previous_frame"
+        json_like_dict_c["alg_diffusion_cond_embed"] = alg_diffusion_cond_embed
 
         opt = TrainOptions().parse_json(json_like_dict_c, save_config=True)
         train.launch_training(opt)

--- a/tests/test_run_diffusion.py
+++ b/tests/test_run_diffusion.py
@@ -45,7 +45,7 @@ G_unet_mha_norm_layer = [
     "switchablenorm",
 ]
 
-alg_palette_conditioning = [
+alg_diffusion_cond_embed = [
     "mask"
 ]  # , "class"] class conditioning can't be tested for now because there is no class in the dataset
 
@@ -54,7 +54,7 @@ product_list = product(
     models_diffusion,
     G_netG,
     G_unet_mha_norm_layer,
-    alg_palette_conditioning,
+    alg_diffusion_cond_embed,
     G_efficient,
     train_feat_wavelet,
 )
@@ -68,7 +68,7 @@ def test_semantic_mask(dataroot):
         model,
         Gtype,
         G_norm,
-        alg_palette_conditioning,
+        alg_diffusion_cond_embed,
         G_efficient,
         train_feat_wavelet,
     ) in product_list:
@@ -81,7 +81,7 @@ def test_semantic_mask(dataroot):
         json_like_dict_c["G_unet_mha_norm_layer"] = G_norm
         json_like_dict_c["G_unet_mha_vit_efficient"] = G_efficient
 
-        json_like_dict_c["alg_palette_conditioning"] = alg_palette_conditioning
+        json_like_dict_c["alg_diffusion_cond_embed"] = alg_diffusion_cond_embed
         json_like_dict_c["train_feat_wavelet"] = train_feat_wavelet
 
         opt = TrainOptions().parse_json(json_like_dict_c)

--- a/tests/test_run_pix2pix_diffusion.py
+++ b/tests/test_run_pix2pix_diffusion.py
@@ -26,7 +26,7 @@ json_like_dict = {
     "G_unet_mha_channel_mults": [1, 2],
     "G_nblocks": 1,
     "G_padding_type": "reflect",
-    "alg_palette_task": "pix2pix",
+    "alg_diffusion_task": "pix2pix",
 }
 
 

--- a/tests/test_run_sr_diffusion.py
+++ b/tests/test_run_sr_diffusion.py
@@ -27,8 +27,8 @@ json_like_dict = {
     "G_unet_mha_channel_mults": [1, 2],
     "G_nblocks": 1,
     "G_padding_type": "reflect",
-    "alg_palette_task": "super_resolution",
-    "alg_palette_super_resolution_scale": 2.0,
+    "alg_diffusion_task": "super_resolution",
+    "alg_diffusion_super_resolution_scale": 2.0,
 }
 
 

--- a/train.py
+++ b/train.py
@@ -148,7 +148,7 @@ def train_gpu(rank, world_size, opt, trainset, trainset_temporal):
         if opt.train_continue:
             opt.train_epoch_count = visualizer.load_data()
 
-        model.print_flop()
+        # model.print_flop()
 
     total_iters = 0  # the total number of training iterations
 


### PR DESCRIPTION
This PR adds support for Consistency Models (https://arxiv.org/abs/2303.01469 and https://arxiv.org/abs/2310.14189).

Usage: 
```
python3 train.py --dataroot /data1/beniz/data/noglasses2glasses_ffhq --checkpoints_dir /home/beniz/checkpoints --name noglasses2glasses --config_json examples/example_cm_noglasses2glasses.json
```

Example: 
![image](https://github.com/jolibrain/joliGEN/assets/3530657/ae6a1ab6-b8c5-4f04-88d5-bfb2c602b087)


Note: some options (and thus doc & examples scripts have been modified) to accomodate the `BaseDiffusion` main class.