### PR TITLE
feat: allow to resume training with a different number of timesteps

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -937,6 +937,13 @@ class BaseModel(ABC):
                             state_dict[new_key] = state_dict[key].clone()
                             del state_dict[key]
 
+                # Don't load test gammas from checkpoint, so that we can use
+                # an arbitrary number of sample steps specified in the command
+                # line arguments or config
+                for key in list(state_dict.keys()):
+                    if key.startswith("denoise_fn") and key.endswith("_test"):
+                        state_dict[key] = net.state_dict()[key]
+
                 state1 = list(state_dict.keys())
                 state2 = list(net.state_dict().keys())
                 state1.sort()


### PR DESCRIPTION
When we resume a diffusion model, maybe we want to change the number of sampling steps or the scheduling during inference. This was not possible because the gammas were reloaded from the checkpoint, and not recomputed according to the user options.

Changing test sampling steps does not have any impact on training, only the visuals are affected.