### PR TITLE
chore: remove run name for test metrics on visdom, to allows for comparisons

### DIFF
--- a/util/visualizer.py
+++ b/util/visualizer.py
@@ -444,7 +444,7 @@ class Visualizer:
                 Y,
                 X,
                 opts={
-                    "title": self.name + " " + title,
+                    "title": title,
                     "legend": plot_metrics["legend"],
                     "xlabel": "epoch",
                     "ylabel": ylabel,


### PR DESCRIPTION
Otherwise metrics cannot be compared across multiple runs with visdom.