### PR TITLE
chore: do not save images used to compute metrics as default

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -1442,7 +1442,9 @@ class BaseModel(ABC):
 
         return metrics
 
-    def compute_metrics_test(self, dataloaders_test, n_epoch, n_iter):
+    def compute_metrics_test(
+        self, dataloaders_test, n_epoch, n_iter, save_images=False
+    ):
         dims = 2048
         batch = 1
 
@@ -1466,7 +1468,6 @@ class BaseModel(ABC):
         for i, data_test_list in enumerate(
             dataloaders_test
         ):  # inner loop (minibatch) within one epoch
-
             data_test = data_test_list[0]
 
             if self.use_temporal:
@@ -1480,16 +1481,21 @@ class BaseModel(ABC):
             offset = i * self.opt.test_batch_size
             self.inference(self.opt.test_batch_size, offset=offset)
 
-            pathB = self.save_dir + "/fakeB/%s_epochs_%s_iters_imgs" % (n_epoch, n_iter)
-            if not os.path.exists(pathB):
-                os.mkdir(pathB)
+            if save_images:
+                pathB = self.save_dir + "/fakeB/%s_epochs_%s_iters_imgs" % (
+                    n_epoch,
+                    n_iter,
+                )
+                if not os.path.exists(pathB):
+                    os.mkdir(pathB)
 
             for j, cur_fake_B in enumerate(self.fake_B):
-                save_image(
-                    tensor2im(cur_fake_B.unsqueeze(0)),
-                    pathB + "/" + str(offset + j) + ".png",
-                    aspect_ratio=1.0,
-                )
+                if save_images:
+                    save_image(
+                        tensor2im(cur_fake_B.unsqueeze(0)),
+                        pathB + "/" + str(offset + j) + ".png",
+                        aspect_ratio=1.0,
+                    )
 
                 fake_list.append(cur_fake_B.unsqueeze(0).clone())
 

--- a/options/train_options.py
+++ b/options/train_options.py
@@ -217,6 +217,11 @@ class TrainOptions(CommonOptions):
             choices=["FID", "KID", "MSID", "PSNR", "LPIPS", "SSIM"],
             help="metrics on results quality to compute",
         )
+        parser.add_argument(
+            "--train_metrics_save_images",
+            action="store_true",
+            help="whether to save images that result form metrics computation",
+        )
 
         parser.add_argument(
             "--train_G_ema",

--- a/train.py
+++ b/train.py
@@ -273,7 +273,10 @@ def train_gpu(rank, world_size, opt, trainset, trainset_temporal):
                                 dataloaders_test = zip(dataloader_test)
 
                             model.compute_metrics_test(
-                                dataloaders_test, epoch, opt.total_iters
+                                dataloaders_test,
+                                epoch,
+                                opt.total_iters,
+                                opt.train_metrics_save_images,
                             )
 
                             visualizer.display_current_results(
@@ -361,7 +364,10 @@ def train_gpu(rank, world_size, opt, trainset, trainset_temporal):
             else:
                 dataloaders_test = zip(dataloader_test)
             model.compute_metrics_test(
-                dataloaders_test, opt.train_epoch_count - 1, opt.total_iters
+                dataloaders_test,
+                opt.train_epoch_count - 1,
+                opt.total_iters,
+                save_images=opt.train_metrics_save_images,
             )
             cur_metrics = model.get_current_metrics()
         path_json = os.path.join(opt.checkpoints_dir, opt.name, "eval_results.json")


### PR DESCRIPTION
This PR deactivates saving metrics images by default. On long runs, these images come in millions, and are useless in practice.