### PR TITLE
chore: clamp input real images before psnr to avoid errors

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -1615,7 +1615,7 @@ class BaseModel(ABC):
             setattr(self, "fidB_test_" + test_name, fidB_test)
             setattr(self, "msidB_test_" + test_name, msidB_test)
             setattr(self, "kidB_test_" + test_name, kidB_test)
-        real_tensor = (torch.cat(real_list) + 1.0) / 2.0
+        real_tensor = (torch.clamp(torch.cat(real_list), min=-1.0, max=1.0) + 1.0) / 2.0
         fake_tensor = (torch.clamp(torch.cat(fake_list), min=-1.0, max=1.0) + 1.0) / 2.0
 
         psnr_test = psnr(real_tensor, fake_tensor)


### PR DESCRIPTION
Some inputs may have slightly negative values (they shouldn't), thus failing some metrics computations.