### PR TITLE
feat: max number of visualized images from train/test set

### DIFF
--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -162,7 +162,10 @@ class CUTModel(BaseGanModel):
     def __init__(self, opt, rank):
         super().__init__(opt, rank)
 
-        max_visual_outputs = max(self.opt.train_batch_size, self.opt.num_test_images)
+        max_visual_outputs = min(
+            max(self.opt.train_batch_size, self.opt.num_test_images),
+            self.opt.output_num_images,
+        )
 
         # Images to visualize
         visual_names_A = ["real_A", "fake_B"]

--- a/models/palette_model.py
+++ b/models/palette_model.py
@@ -104,7 +104,10 @@ class PaletteModel(BaseDiffusionModel):
         else:
             batch_size = self.opt.test_batch_size
 
-        max_visual_outputs = max(self.opt.train_batch_size, self.opt.num_test_images)
+        max_visual_outputs = min(
+            max(self.opt.train_batch_size, self.opt.num_test_images),
+            self.opt.output_num_images,
+        )
 
         self.num_classes = max(
             self.opt.f_s_semantic_nclasses, self.opt.cls_semantic_nclasses

--- a/options/train_options.py
+++ b/options/train_options.py
@@ -120,6 +120,12 @@ class TrainOptions(CommonOptions):
             help="if True x - G(x) is displayed",
         )
         parser.add_argument("--output_display_G_attention_masks", action="store_true")
+        parser.add_argument(
+            "--output_num_images",
+            type=int,
+            default=20,
+            help="number of visualized images results from the train/test set",
+        )
 
         # network saving and loading parameters
         parser.add_argument(


### PR DESCRIPTION
Adds `--output_num_images` to limit the number of visualized images.