### PR TITLE
random canny dropout for vid

### DIFF
--- a/models/base_diffusion_model.py
+++ b/models/base_diffusion_model.py
@@ -211,6 +211,12 @@ class BaseDiffusionModel(BaseModel):
             choices=["clip", "imagebind"],
             help="embedding network to use for ref conditioning",
         )
+        parser.add_argument(
+            "--alg_diffusion_vid_canny_dropout",
+            type=float,
+            default=0,
+            help="prob to drop canny for each frame",
+        )
 
         return parser
 

--- a/models/modules/diffusion_generator.py
+++ b/models/modules/diffusion_generator.py
@@ -452,6 +452,7 @@ class DiffusionGenerator(nn.Module):
         if len(y_0.shape) == 5:
             sequence_length = y_0.shape[1]
             y_0, y_cond, mask = rearrange_5dto4d_fh(y_0, y_cond, mask)
+
         b, *_ = y_0.shape
 
         t = torch.randint(

--- a/util/mask_generation.py
+++ b/util/mask_generation.py
@@ -34,24 +34,6 @@ def fill_img_with_sketch(img, mask, **kwargs):
     return mask * thresh + (1 - mask) * img
 
 
-def fill_mask_with_canny_dropout(
-    img,
-    mask,
-    sequence_length,
-    dropout=0.9,
-    **kwargs,
-):
-    """Fill the masked region with fill_value"""
-    fill_tensor = torch.full_like(mask, -1)
-    mask = torch.clamp(mask, 0, 1)
-    output_img = mask * fill_tensor + (1 - mask) * img
-    frame_dropout = [
-        1 if random.random() > dropout else 0 for _ in range(sequence_length)
-    ]
-
-    return output_img, frame_dropout
-
-
 def fill_img_with_canny(
     img,
     mask,
@@ -62,63 +44,14 @@ def fill_img_with_canny(
     """Fill the masked region with canny edges."""
     low_threshold_random = kwargs["low_threshold_random"]
     high_threshold_random = kwargs["high_threshold_random"]
-    vary_thresholds = kwargs.get("vary_thresholds", False)
+    canny_list = kwargs["select_canny"]
     max_value = 255 * 3
+
     device = img.device
     edges_list = []
-    threshold_pairs = []
-    for _ in range(img.shape[0]):
-        if (high_threshold is None and low_threshold is None) or (
-            vary_thresholds == True
-        ):
-            threshold_1 = random.randint(low_threshold_random, high_threshold_random)
-            threshold_2 = random.randint(low_threshold_random, high_threshold_random)
-            high_threshold = max(threshold_1, threshold_2)
-            low_threshold = min(threshold_1, threshold_2)
-        elif high_threshold is None and low_threshold is not None:
-            high_threshold = random.randint(low_threshold, max_value)
-        elif high_threshold is not None and low_threshold is None:
-            low_threshold = random.randint(0, high_threshold)
-        threshold_pairs.append((low_threshold, high_threshold))
-    for idx, cur_img in enumerate(img):
-
-        if vary_thresholds:
-            low_threshold, high_threshold = threshold_pairs[idx]
-        else:
-            low_threshold, high_threshold = threshold_pairs[0]
-        cur_img = (
-            (torch.einsum("chw->hwc", cur_img).cpu().numpy() + 1) * 255 / 2
-        ).astype(np.uint8)
-        edges = cv2.Canny(cur_img, low_threshold, high_threshold)
-        edges = (
-            (((torch.tensor(edges, device=device) / 255) * 2) - 1)
-            .unsqueeze(0)
-            .unsqueeze(0)
-        )
-        edges_list.append(edges)
-    edges = torch.cat(edges_list, dim=0)
-    mask = torch.clamp(mask, 0, 1)
-    return mask * edges + (1 - mask) * img
-
-
-def fill_img_with_canny_ori(
-    img,
-    mask,
-    low_threshold=None,
-    high_threshold=None,
-    **kwargs,
-):
-    """Fill the masked region with canny edges."""
-    low_threshold_random = kwargs["low_threshold_random"]
-    high_threshold_random = kwargs["high_threshold_random"]
-    max_value = 255 * 3
-    device = img.device
-    edges_list = []
-    for cur_img in img:
+    for cur_img, canny in zip(img, canny_list):
         high_threshold = cur_high_threshold
-        low_threshold = (
-            cur_low_threshold  # Reset thresholds for each image for new random
-        )
+        low_threshold = cur_low_threshold
 
         if high_threshold is None and low_threshold is None:
             threshold_1 = random.randint(low_threshold_random, high_threshold_random)
@@ -129,10 +62,16 @@ def fill_img_with_canny_ori(
             high_threshold = random.randint(low_threshold, max_value)
         elif high_threshold is not None and low_threshold is None:
             low_threshold = random.randint(0, high_threshold)
+
         cur_img = (
             (torch.einsum("chw->hwc", cur_img).cpu().numpy() + 1) * 255 / 2
         ).astype(np.uint8)
-        edges = cv2.Canny(cur_img, low_threshold, high_threshold)
+
+        if canny == 1:
+            edges = cv2.Canny(cur_img, low_threshold, high_threshold)
+        else:  # black image
+            edges = np.zeros_like(cur_img[:, :, 0])
+
         edges = (
             (((torch.tensor(edges, device=device) / 255) * 2) - 1)
             .unsqueeze(0)

--- a/util/mask_generation.py
+++ b/util/mask_generation.py
@@ -34,11 +34,78 @@ def fill_img_with_sketch(img, mask, **kwargs):
     return mask * thresh + (1 - mask) * img
 
 
+def fill_mask_with_canny_dropout(
+    img,
+    mask,
+    sequence_length,
+    dropout=0.9,
+    **kwargs,
+):
+    """Fill the masked region with fill_value"""
+    fill_tensor = torch.full_like(mask, -1)
+    mask = torch.clamp(mask, 0, 1)
+    output_img = mask * fill_tensor + (1 - mask) * img
+    frame_dropout = [
+        1 if random.random() > dropout else 0 for _ in range(sequence_length)
+    ]
+
+    return output_img, frame_dropout
+
+
 def fill_img_with_canny(
     img,
     mask,
     cur_low_threshold=None,
     cur_high_threshold=None,
+    **kwargs,
+):
+    """Fill the masked region with canny edges."""
+    low_threshold_random = kwargs["low_threshold_random"]
+    high_threshold_random = kwargs["high_threshold_random"]
+    vary_thresholds = kwargs.get("vary_thresholds", False)
+    max_value = 255 * 3
+    device = img.device
+    edges_list = []
+    threshold_pairs = []
+    for _ in range(img.shape[0]):
+        if (high_threshold is None and low_threshold is None) or (
+            vary_thresholds == True
+        ):
+            threshold_1 = random.randint(low_threshold_random, high_threshold_random)
+            threshold_2 = random.randint(low_threshold_random, high_threshold_random)
+            high_threshold = max(threshold_1, threshold_2)
+            low_threshold = min(threshold_1, threshold_2)
+        elif high_threshold is None and low_threshold is not None:
+            high_threshold = random.randint(low_threshold, max_value)
+        elif high_threshold is not None and low_threshold is None:
+            low_threshold = random.randint(0, high_threshold)
+        threshold_pairs.append((low_threshold, high_threshold))
+    for idx, cur_img in enumerate(img):
+
+        if vary_thresholds:
+            low_threshold, high_threshold = threshold_pairs[idx]
+        else:
+            low_threshold, high_threshold = threshold_pairs[0]
+        cur_img = (
+            (torch.einsum("chw->hwc", cur_img).cpu().numpy() + 1) * 255 / 2
+        ).astype(np.uint8)
+        edges = cv2.Canny(cur_img, low_threshold, high_threshold)
+        edges = (
+            (((torch.tensor(edges, device=device) / 255) * 2) - 1)
+            .unsqueeze(0)
+            .unsqueeze(0)
+        )
+        edges_list.append(edges)
+    edges = torch.cat(edges_list, dim=0)
+    mask = torch.clamp(mask, 0, 1)
+    return mask * edges + (1 - mask) * img
+
+
+def fill_img_with_canny_ori(
+    img,
+    mask,
+    low_threshold=None,
+    high_threshold=None,
     **kwargs,
 ):
     """Fill the masked region with canny edges."""


### PR DESCRIPTION
random canny for each image in one sequence, and with canny dropout for each image. 
The dropout is hard coded for the moment, in  "models/palette_model.py" 
cond_image_nocanny, frame_select = fill_mask_with_canny_dropout(
                            self.gt_image,
                            self.mask,
                            self.opt.data_temporal_number_frames,
                            0.9,
                        )
I print frame_select is to check weather the selected frame in one sequence was suppose to have canny.

```
python3 -W ignore::UserWarning  train.py \
--dataroot /path/to/online_mario2sonic_full_mario  \
--checkpoints_dir  /path/to/checkpoints \
--name mario_vid_canny_random_dropout0.9_bs1it16_fix1  \
--gpu_ids 0,1,2    \
--model_type palette \
--output_print_freq 100   \
--output_display_freq 500  \
--data_dataset_mode  self_supervised_temporal_labeled_mask_online  \
--train_batch_size 1  \
--train_iter_size 16  \
--model_input_nc 3 \
--model_output_nc 3 \
--data_relative_paths \
--train_G_ema \
--train_optim adamw \
--G_netG unet_vid   \
--data_online_creation_crop_size_A 64  \
--data_online_creation_crop_size_B 64 \
--data_crop_size 64 \
--data_load_size 64  \
--data_online_creation_rand_mask_A \
--train_G_lr 0.0001 \
--dataaug_no_rotate \
--G_diff_n_timestep_train  2000   \
--G_diff_n_timestep_test  1000   \
--data_temporal_number_frames 8  \
--data_temporal_frame_step 1 \
--data_online_creation_mask_delta_A_ratio 0.12 0.12 \
--alg_diffusion_cond_image_creation    computed_sketch  \
--alg_diffusion_cond_computed_sketch_list canny \
```
