### PR TITLE
vid_dropout_variance

### DIFF
--- a/models/base_diffusion_model.py
+++ b/models/base_diffusion_model.py
@@ -213,9 +213,10 @@ class BaseDiffusionModel(BaseModel):
         )
         parser.add_argument(
             "--alg_diffusion_vid_canny_dropout",
-            type=float,
-            default=0,
-            help="prob to drop canny for each frame",
+            type=pairs_of_floats,
+            default=[[]],
+            nargs="+",
+            help="the range of probabilities for dropping the canny for each frame",
         )
 
         return parser

--- a/models/palette_model.py
+++ b/models/palette_model.py
@@ -405,9 +405,11 @@ class PaletteModel(BaseDiffusionModel):
                         )
 
                     random_num = torch.rand(self.gt_image.shape[0])
-                    canny_frame = (
-                        random_num > self.opt.alg_diffusion_vid_canny_dropout
-                    ).int()  # binary canny_frame
+                    dropout_pro = torch.empty(self.gt_image.shape[0]).uniform_(
+                        self.opt.alg_diffusion_vid_canny_dropout[0][0],
+                        self.opt.alg_diffusion_vid_canny_dropout[1][0],
+                    )
+                    canny_frame = (random_num > dropout_pro).int()  # binary canny_frame
                     self.cond_image = fill_img_with_random_sketch(
                         self.gt_image,
                         self.mask,


### PR DESCRIPTION
For video generation with Canny conditions, the option --alg_diffusion_vid_canny_dropout provides a range of dropout probabilities for the Canny dropout effect applied to each frame.

Example of execution.  It works with:

```
python3 -W ignore::UserWarning  train.py \
--dataroot /path/to/online_mario2sonic_full_mario  \
--checkpoints_dir  /path/to/checkpoints \
--name mario_vid  \
--gpu_ids 3    \
--model_type palette \
--output_print_freq 1   \
--output_display_freq 1   \
--data_dataset_mode  self_supervised_temporal_labeled_mask_online  \
--train_batch_size 2  \
--train_iter_size 1  \
--model_input_nc 3 \
--model_output_nc 3 \
--data_relative_paths \
--train_G_ema \
--train_optim adamw \
--G_netG unet_vid   \
--data_online_creation_crop_size_A 32  \
--data_online_creation_crop_size_B 32 \
--data_crop_size 32 \
--data_load_size 32  \
--data_online_creation_rand_mask_A \
--train_G_lr 0.0001 \
--dataaug_no_rotate \
--G_diff_n_timestep_train  6  \
--G_diff_n_timestep_test  4  \
--data_temporal_number_frames 8  \
--data_temporal_frame_step 1 \
--data_online_creation_mask_delta_A_ratio 0.12 0.12 \
--alg_diffusion_cond_image_creation    computed_sketch  \
--alg_diffusion_cond_computed_sketch_list canny \
--alg_diffusion_vid_canny_dropout 0.1 0.8 
```