### PR TITLE
option for max_sequence_length of video generation

### DIFF
--- a/models/diffusion_networks.py
+++ b/models/diffusion_networks.py
@@ -39,7 +39,7 @@ def define_G(
     G_attn_nb_mask_attn,
     G_attn_nb_mask_input,
     G_spectral,
-    G_unet_vid_max_frame,
+    G_unet_vid_max_sequence_length,
     jg_dir,
     G_padding_type,
     G_config_segformer,
@@ -150,7 +150,7 @@ def define_G(
             efficient=G_unet_mha_vit_efficient,
             cond_embed_dim=cond_embed_dim,
             freq_space=train_feat_wavelet,
-            max_frame=G_unet_vid_max_frame,
+            max_sequence_length=G_unet_vid_max_sequence_length,
         )
 
     elif G_netG == "unet_mha_ref_attn":

--- a/models/modules/unet_generator_attn/unet_generator_attn_vid.py
+++ b/models/modules/unet_generator_attn/unet_generator_attn_vid.py
@@ -397,7 +397,6 @@ class MotionModule(nn.Module):
             temporal_position_encoding=temporal_position_encoding,
             temporal_position_encoding_max_len=temporal_position_encoding_max_len,
         )
-
         if zero_initialize:
             self.temporal_transformer.proj_out = zero_module(
                 self.temporal_transformer.proj_out
@@ -532,7 +531,6 @@ class TemporalTransformerBlock(nn.Module):
         temporal_position_encoding_max_len=25,
     ):
         super().__init__()
-
         attention_blocks = []
         norms = []
 
@@ -555,7 +553,6 @@ class TemporalTransformerBlock(nn.Module):
                 )
             )
             norms.append(nn.LayerNorm(dim))
-
         self.attention_blocks = nn.ModuleList(attention_blocks)
         self.norms = nn.ModuleList(norms)
 
@@ -962,7 +959,6 @@ class VersatileAttention(CrossAttention):
 
         self.attention_mode = attention_mode
         self.is_cross_attention = kwargs["cross_attention_dim"] is not None
-
         self.pos_encoder = (
             PositionalEncoding(
                 kwargs["query_dim"],
@@ -1109,7 +1105,7 @@ class UNetVid(nn.Module):
         use_new_attention_order=True,  # False,
         efficient=False,
         freq_space=False,
-        max_frame=25,
+        max_sequence_length=25,
     ):
         super().__init__()
 
@@ -1132,8 +1128,7 @@ class UNetVid(nn.Module):
         self.num_head_channels = num_head_channels
         self.num_heads_upsample = num_heads_upsample
         self.freq_space = freq_space
-        self.max_frame = max_frame
-
+        self.max_sequence_length = max_sequence_length
         if self.freq_space:
             from ..freq_utils import InverseHaarTransform, HaarTransform
 
@@ -1188,7 +1183,7 @@ class UNetVid(nn.Module):
                         attention_block_types=("Temporal_self", "Temporal_Self"),
                         cross_frame_attention_mode=None,
                         temporal_position_encoding=True,
-                        temporal_position_encoding_max_len=25,  # self.max_frame,
+                        temporal_position_encoding_max_len=self.max_sequence_length,
                         temporal_attention_dim_div=1,
                         zero_initialize=True,
                     )
@@ -1294,7 +1289,7 @@ class UNetVid(nn.Module):
                         attention_block_types=("Temporal_self", "Temporal_Self"),
                         cross_frame_attention_mode=None,
                         temporal_position_encoding=True,
-                        temporal_position_encoding_max_len=25,  # self.max_frame,
+                        temporal_position_encoding_max_len=self.max_sequence_length,
                         temporal_attention_dim_div=1,
                         zero_initialize=True,
                     )

--- a/options/common_options.py
+++ b/options/common_options.py
@@ -387,10 +387,10 @@ class CommonOptions(BaseOptions):
             help="Patch size for HDIT, e.g. 4 for 4x4 patches",
         )
         parser.add_argument(
-            "--G_unet_vid_max_frame",
-            default=24,
+            "--G_unet_vid_max_sequence_length",
+            default=25,
             type=int,
-            help="max frame number for unet_vid in the PositionalEncoding",
+            help="max frame number(sequence length) for unet_vid in the PositionalEncoding",
         )
 
         # parser.add_argument(


### PR DESCRIPTION
Create an option for the maximum sequence length for video generation, --vid_max_sequence_length. The data_temporal_number_frames value should not exceed --vid_max_sequence_length

Example of execution. It works with:

```
python3 -W ignore::UserWarning  train.py \
--dataroot /path/to/online_mario2sonic_full_mario  \
--checkpoints_dir  /path/to/checkpoints \
--name  mario_vid   \
--gpu_ids 0    \
--model_type palette \
--output_print_freq 1   \
--output_display_freq 1   \
--data_dataset_mode  self_supervised_temporal_labeled_mask_online  \
--train_batch_size 1  \
--train_iter_size 1  \
--model_input_nc 3 \
--model_output_nc 3 \
--data_relative_paths \
--train_G_ema \
--train_optim adamw \
--G_netG unet_vid   \
--data_online_creation_crop_size_A 32  \
--data_online_creation_crop_size_B 32 \
--data_crop_size 32 \
--data_load_size 32  \
--data_online_creation_rand_mask_A \
--train_G_lr 0.0001 \
--dataaug_no_rotate \
--G_diff_n_timestep_train  6  \
--G_diff_n_timestep_test  3  \
--data_temporal_number_frames 8  \
--data_temporal_frame_step 1 \
--data_online_creation_mask_delta_A_ratio 0.12 0.12 \
--alg_diffusion_cond_image_creation    computed_sketch  \
--alg_diffusion_cond_computed_sketch_list canny \
--alg_diffusion_vid_canny_dropout 0.1 0.8  \
--alg_diffusion_cond_sketch_canny_range  500 1000  \
--vid_max_sequence_length 24 
```