### PR TITLE
debug  vid metric when train bs > 1

### DIFF
--- a/models/palette_model.py
+++ b/models/palette_model.py
@@ -668,7 +668,7 @@ class PaletteModel(BaseDiffusionModel):
         else:
             for name in self.gen_visual_names:
                 whole_tensor = getattr(self, name[:-1])  # i.e. self.output, ...
-                for bs in range(self.opt.train_batch_size):
+                for bs in range(min(nb_imgs, self.get_current_batch_size())):
                     for k in range(self.opt.data_temporal_number_frames):
                         cur_name = name + str(
                             offset + bs * (self.opt.data_temporal_number_frames) + k


### PR DESCRIPTION
it works with:

python3 -W ignore::UserWarning train.py   \
--dataroot /data1/juliew/dataset/online_mario2sonic_full_mario/  \
--checkpoints_dir /data1/juliew/checkpoints     \
--name mario_vid        \
--gpu_ids 0     \
--model_type palette    \
--output_print_freq 1   \
--output_display_freq 1 \
--data_dataset_mode self_supervised_temporal_labeled_mask_online        \
--train_batch_size 2    \
--train_iter_size 1     \
--model_input_nc 3      \
--model_output_nc 3     \
--data_relative_paths   \
--train_G_ema   \
--train_optim adamw     \
--G_netG unet_vid       \
--data_online_creation_crop_size_A 32   \
--data_online_creation_crop_size_B 32   \
--data_crop_size 32     \
--data_load_size 32     \
--data_online_creation_rand_mask_A      \
--train_G_lr 0.0001     \
--dataaug_no_rotate     \
--G_diff_n_timestep_train 6     \
--G_diff_n_timestep_test 3      \
--data_temporal_number_frames 3 \
--data_temporal_frame_step 1    \
--data_online_creation_mask_delta_A_ratio 0.12 0.12     \
--alg_diffusion_cond_image_creation computed_sketch     \
--alg_diffusion_cond_computed_sketch_list canny \
--alg_diffusion_cond_sketch_canny_range  500 1000  \
--train_compute_metrics_test   \
--train_metrics_every  1  \
--train_metrics_list  PSNR LPIPS SSIM   \