### PR TITLE
vid canny dropout threshold 

### DIFF
--- a/models/palette_model.py
+++ b/models/palette_model.py
@@ -377,8 +377,8 @@ class PaletteModel(BaseDiffusionModel):
                         batch_cond_image = fill_img_with_random_sketch(
                             image.unsqueeze(0),
                             mask.unsqueeze(0),
-                            low_threshold_random=low,
-                            high_threshold_random=high,
+                            cur_low_threshold_random=low,
+                            cur_high_threshold_random=high,
                         ).squeeze(0)
                     elif "sam" in fill_img_with_random_sketch.__name__:
                         batch_cond_image = fill_img_with_random_sketch(


### PR DESCRIPTION
Dubug for canny range within the given threshold, it works with:

python3 -W ignore::UserWarning  train.py \
--dataroot /data1/juliew/ori_dataset/conti_3in1  \
--checkpoints_dir /data1/juliew/checkpoints  \
--name test_debug   \
--gpu_ids 0  \
--data_relative_paths   \
--model_type palette \
--data_dataset_mode  self_supervised_vid_mask_online  \
--train_batch_size 1  \
--train_iter_size 1  \
--data_num_threads  1  \
--model_input_nc 3 \
--model_output_nc 3 \
--data_relative_paths \
--train_G_ema \
--train_optim adamw \
--G_netG unet_vid   \
--data_online_creation_rand_mask_A \
--train_G_lr 0.0002 \
--dataaug_no_rotate \
--G_diff_n_timestep_train  2  \
--G_diff_n_timestep_test  3   \
--data_temporal_frame_step 1 \
--alg_diffusion_cond_image_creation    computed_sketch  \
--alg_diffusion_cond_computed_sketch_list canny \
--alg_diffusion_cond_sketch_canny_range  0 100 \
--alg_diffusion_vid_canny_dropout  0.0 0.0 \
--online_creation_mask_random_offset_A 0.2 \
--output_print_freq 1   \
--output_display_freq 1  \
--data_temporal_number_frames  4  \
--data_online_creation_crop_size_A 128  \
--data_online_creation_crop_size_B 128  \
--data_crop_size 128  \
--data_load_size 128   \