### PR TITLE
fix for canny range  and dropout

### DIFF
--- a/util/mask_generation.py
+++ b/util/mask_generation.py
@@ -37,8 +37,8 @@ def fill_img_with_sketch(img, mask, **kwargs):
 def fill_img_with_canny(
     img,
     mask,
-    cur_low_threshold=None,
-    cur_high_threshold=None,
+    low_threshold=None,
+    high_threshold=None,
     **kwargs,
 ):
     """Fill the masked region with canny edges."""
@@ -50,8 +50,8 @@ def fill_img_with_canny(
     device = img.device
     edges_list = []
     for cur_img, canny in zip(img, canny_list):
-        high_threshold = cur_high_threshold
-        low_threshold = cur_low_threshold
+        high_threshold = high_threshold_random
+        low_threshold = low_threshold_random
 
         if high_threshold is None and low_threshold is None:
             threshold_1 = random.randint(low_threshold_random, high_threshold_random)


### PR DESCRIPTION
```
python3 -W ignore::UserWarning  train.py \
--dataroot  /path/to/data    \
--checkpoints_dir /path/to/checkpoints  \
--name test_conti  \
--gpu_ids 2  \
--data_relative_paths   \ 
--model_type palette \
--data_dataset_mode  self_supervised_vid_mask_online  \
--train_batch_size 2  \
--train_iter_size 8  \
--data_num_threads  16  \
--model_input_nc 3 \
--model_output_nc 3 \
--data_relative_paths \ 
--train_G_ema \
--train_optim adamw \
--G_netG unet_vid   \
--data_online_creation_rand_mask_A \
--train_G_lr 0.0001 \
--dataaug_no_rotate \
--G_diff_n_timestep_train  6  \
--G_diff_n_timestep_test  3   \
--data_temporal_frame_step 1 \ 
--alg_diffusion_cond_image_creation    computed_sketch  \
--alg_diffusion_cond_computed_sketch_list canny \
--alg_diffusion_cond_sketch_canny_range 50 100 \
--alg_diffusion_vid_canny_dropout  0 0 \
--online_creation_mask_random_offset_A 0.2 \
--output_print_freq 1   \
--output_display_freq 1  \
--data_temporal_number_frames  8  \
--data_online_creation_crop_size_A 64  \
--data_online_creation_crop_size_B 64  \
--data_crop_size 64  \
--data_load_size 64   \
--ddp_port 12344  \ 
--train_compute_metrics_test   \
--train_metrics_every 1  \
--train_metrics_list PSNR LPIPS SSIM \
```