### PR TITLE
fix vid dataloader for frame limit

### DIFF
--- a/data/self_supervised_vid_mask_online_dataset.py
+++ b/data/self_supervised_vid_mask_online_dataset.py
@@ -68,7 +68,7 @@ class SelfSupervisedVidMaskOnlineDataset(BaseDataset):
         )
         # Initialize a dictionary to count how many available paths belong to each directory
         self.frames_counts = {
-            vid_serie: -self.num_frames * self.frame_step
+            vid_serie: (-self.num_frames + 1) * self.frame_step
             for vid_serie in self.vid_series_paths
         }
         # Loop through self.A_img_paths and count the occurrences of each directory
@@ -112,7 +112,10 @@ class SelfSupervisedVidMaskOnlineDataset(BaseDataset):
     ):  # all params are unused
 
         if len(self.frames_counts) == 1:  # single video mario
-            index_A = random.randint(0, self.range_A - 1)
+            if self.range_A == 0:
+                index_A = 0
+            else:
+                index_A = random.randint(0, self.range_A - 1)
         else:  # video series
             range_A = self.cumulative_sums[
                 -1


### PR DESCRIPTION
python3 -W ignore::UserWarning  train.py \
--dataroot /path/to/dataset    \
--checkpoints_dir /path/to/checkpoints  \
--name test_debug   \
--gpu_ids 0  \
--data_relative_paths   \
--model_type palette \
--data_dataset_mode  self_supervised_vid_mask_online  \
--train_batch_size 1  \
--train_iter_size 1  \
--data_num_threads  1  \
--model_input_nc 3 \
--model_output_nc 3 \
--data_relative_paths \
--train_G_ema \
--train_optim adamw \
--G_netG unet_vid   \
--data_online_creation_rand_mask_A \
--train_G_lr 0.0002 \
--dataaug_no_rotate \
--G_diff_n_timestep_train  6  \
--G_diff_n_timestep_test  3   \
--data_temporal_frame_step 1 \
--alg_diffusion_cond_image_creation    computed_sketch  \
--alg_diffusion_cond_computed_sketch_list canny \
--diffusion_cond_sketch_canny_range 0 150 \
--alg_diffusion_vid_canny_dropout  0.0 0.0 \
--train_compute_metrics_test   \
--train_metrics_every 1  \
--train_metrics_list PSNR LPIPS SSIM \
--output_print_freq 1   \
--output_display_freq 1  \
--data_temporal_number_frames  8  \
--data_online_creation_crop_size_A 32  \
--data_online_creation_crop_size_B 32  \
--data_crop_size 32  \
--data_load_size 32   \
