### PR TITLE
chore: pin timm to v1.0.9 to avoid recently introduced issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ xformers
 numpy==1.23.1
 pluggy==1.3.0
 Pillow
-timm
+timm==1.0.9
 visdom
 torchviz
 imgaug


### PR DESCRIPTION
 https://github.com/huggingface/pytorch-image-models/commit/60f517c88327a64d44fb7259bb427c7658fdbb1b