### PR TITLE
add option for vid inference

### DIFF
--- a/options/inference_diffusion_options.py
+++ b/options/inference_diffusion_options.py
@@ -279,6 +279,18 @@ class InferenceDiffusionOptions(BaseOptions):
             action="store_true",
             help="whether to use refined mask with sam",
         )
+        parser.add_argument(
+            "--vid_frame_extension_number",
+            type=int,
+            default=0,
+            help="additional sequence number added during the inference",
+        )
+        parser.add_argument(
+            "--vid_fps",
+            type=float,
+            default=1.0,
+            help="fps during the inference video generation",
+        )
 
         self.isTrain = False
         return parser

--- a/scripts/gen_vid_diffusion.py
+++ b/scripts/gen_vid_diffusion.py
@@ -171,6 +171,7 @@ def generate(
     sampling_steps,
     img_in,
     mask_in,
+    vid_frame_extension_number,
     ref_in,
     bbox_in,
     cond_in,
@@ -262,12 +263,12 @@ def generate(
         0,
         len(image_bbox_pairs)
         - opt.data_temporal_number_frames
-        - args.vid_frame_extension_number,
+        - vid_frame_extension_number,
     )
     limited_image_bbox_pairs = image_bbox_pairs[
         startframe : startframe
         + opt.data_temporal_number_frames
-        + args.vid_frame_extension_number
+        + vid_frame_extension_number
     ]
     limited_paths_img = [pair[0] for pair in limited_image_bbox_pairs]
     limited_paths_bbox = [pair[1] for pair in limited_image_bbox_pairs]
@@ -281,7 +282,7 @@ def generate(
     out_img_list = []
     sequence_count = 0
     select_canny_list = [0] * (
-        opt.data_temporal_number_frames - 1 + args.vid_frame_extension_number
+        opt.data_temporal_number_frames - 1 + vid_frame_extension_number
     ) + [1]
     for img_path, bbox_path in zip(limited_paths_img, limited_paths_bbox):
         img_in = os.path.join(os.path.dirname(os.path.dirname(paths_in_file)), img_path)

--- a/scripts/gen_vid_diffusion.py
+++ b/scripts/gen_vid_diffusion.py
@@ -257,13 +257,17 @@ def generate(
         parts = line.strip().split()
         image_bbox_pairs.append((parts[0], parts[1]))
     image_bbox_pairs.sort(key=lambda x: natural_keys(x[0]))
-    additional_frame = 0  # sum of opt.data_temporal_number_frames/additional_frame should less than option G_unet_vid_max_frame
 
     startframe = random.randint(
-        0, len(image_bbox_pairs) - opt.data_temporal_number_frames - additional_frame
+        0,
+        len(image_bbox_pairs)
+        - opt.data_temporal_number_frames
+        - args.vid_frame_extension_number,
     )
     limited_image_bbox_pairs = image_bbox_pairs[
-        startframe : startframe + opt.data_temporal_number_frames + additional_frame
+        startframe : startframe
+        + opt.data_temporal_number_frames
+        + args.vid_frame_extension_number
     ]
     limited_paths_img = [pair[0] for pair in limited_image_bbox_pairs]
     limited_paths_bbox = [pair[1] for pair in limited_image_bbox_pairs]
@@ -276,7 +280,9 @@ def generate(
     img_tensor_list = []
     out_img_list = []
     sequence_count = 0
-    select_canny_list = [1] + [0] * (opt.data_temporal_number_frames - 1)
+    select_canny_list = [0] * (
+        opt.data_temporal_number_frames - 1 + args.vid_frame_extension_number
+    ) + [1]
     for img_path, bbox_path in zip(limited_paths_img, limited_paths_bbox):
         img_in = os.path.join(os.path.dirname(os.path.dirname(paths_in_file)), img_path)
         bbox_in = os.path.join(
@@ -940,7 +946,7 @@ def img2video(args):
             video = cv2.VideoWriter(
                 video_path,
                 cv2.VideoWriter_fourcc("M", "J", "P", "G"),
-                0.5,
+                args.vid_fps,
                 (width, height),
             )
             for image in sorted_list:


### PR DESCRIPTION
Add an option `--vid_fps` to specify the frames per second (FPS) for video generation, and an option `--vid_frame_extension_number` to include an additional frame for inference.
it works with 
```
cd scripts/
mkdir -p ../inference_mario/1017   && \
python3 -W ignore::UserWarning  gen_vid_diffusion.py  \
--img_in   /data1/paths_part.txt  \
--mask_in /paths_part.txt    \
--model_in_file  path/to/latest_net_G_A.pth  \
--paths_in_file   path/to/paths.txt\
--dir_out  ../inference_mario/1017  \
--sampling_steps 3  \
--gpuid 0  \
--vid_fps 1  \
--vid_frame_extension_number  6 \
```