### PR TITLE
feat: train_finetune 

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -697,7 +697,14 @@ class BaseModel(ABC):
                 if opt.train_load_iter > 0
                 else opt.train_epoch
             )
-            self.load_networks(load_suffix)
+            if opt.train_finetune:
+                # allow network to not already exists
+                try:
+                    self.load_networks(load_suffix)
+                except Exception as e:
+                    print(e)
+            else:
+                self.load_networks(load_suffix)
 
     def parallelize(self, rank):
         for name in self.model_names:

--- a/options/train_options.py
+++ b/options/train_options.py
@@ -157,11 +157,18 @@ class TrainOptions(CommonOptions):
             action="store_true",
             help="continue training: load the latest model",
         )
+
         parser.add_argument(
             "--train_epoch_count",
             type=int,
             default=1,
             help="the starting epoch count, we save the model by <epoch_count>, <epoch_count>+<save_latest_freq>, ...",
+        )
+
+        parser.add_argument(
+            "--train_finetune",
+            action="store_true",
+            help="sets the models into finetune mode, i.e. less checks are applied, e.g. whether a network already exists, to be used in combination with --train_continue",
         )
 
         # training parameters


### PR DESCRIPTION
Adds option `--train_finetune` to be used in combination with `--train_continue` in order to finetune networks by adding a new discriminator for instance, and removing losses.

Main usage: pre-train supervisedly and finetune on unpaired dataset with new discriminator.