### PR TITLE
fix for dataaug(crop delta) during the video generation

### DIFF
--- a/data/self_supervised_vid_mask_online_dataset.py
+++ b/data/self_supervised_vid_mask_online_dataset.py
@@ -195,7 +195,7 @@ class SelfSupervisedVidMaskOnlineDataset(BaseDataset):
                     mask_random_offset=self.opt.data_online_creation_mask_random_offset_A,
                     crop_delta=0,
                     mask_square=self.opt.data_online_creation_mask_square_A,
-                    crop_dim=self.opt.data_online_creation_crop_size_A,
+                    crop_dim=crop_size,
                     output_dim=self.opt.data_load_size,
                     context_pixels=self.opt.data_online_context_pixels,
                     load_size=self.opt.data_online_creation_load_size_A,
@@ -210,12 +210,13 @@ class SelfSupervisedVidMaskOnlineDataset(BaseDataset):
                     mask_random_offset=self.opt.data_online_creation_mask_random_offset_A,
                     crop_delta=0,
                     mask_square=self.opt.data_online_creation_mask_square_A,
-                    crop_dim=self.opt.data_online_creation_crop_size_A,
+                    crop_dim=crop_size,
                     output_dim=self.opt.data_load_size,
                     context_pixels=self.opt.data_online_context_pixels,
                     load_size=self.opt.data_online_creation_load_size_A,
                     crop_coordinates=crop_coordinates,
                     fixed_mask_size=self.opt.data_online_fixed_mask_size,
+                    crop_center=True,
                 )
                 if i == 0:
                     A_ref_bbox = ref_A_bbox[1:]

--- a/data/self_supervised_vid_mask_online_dataset.py
+++ b/data/self_supervised_vid_mask_online_dataset.py
@@ -153,6 +153,16 @@ class SelfSupervisedVidMaskOnlineDataset(BaseDataset):
         ref_A_img_path = self.A_img_paths[index_A]
         ref_name_A = ref_A_img_path.split("/")[-1][: self.num_common_char]
 
+        crop_size_min = (
+            self.opt.data_online_creation_crop_size_A
+            - self.opt.data_online_creation_crop_delta_A
+        )
+        crop_size_max = (
+            self.opt.data_online_creation_crop_size_A
+            + self.opt.data_online_creation_crop_delta_A
+        )
+        crop_size = random.randint(crop_size_min, crop_size_max)
+
         for i in range(self.num_frames):
             cur_index_A = index_A + i * self.frame_step
 
@@ -178,27 +188,27 @@ class SelfSupervisedVidMaskOnlineDataset(BaseDataset):
                 else:
                     mask_delta_A = self.opt.data_online_creation_mask_delta_A_ratio
 
-                if i == 0:
-                    crop_coordinates = crop_image(
-                        cur_A_img_path,
-                        cur_A_label_path,
-                        mask_delta=mask_delta_A,
-                        mask_random_offset=self.opt.data_online_creation_mask_random_offset_A,
-                        crop_delta=self.opt.data_online_creation_crop_delta_A,
-                        mask_square=self.opt.data_online_creation_mask_square_A,
-                        crop_dim=self.opt.data_online_creation_crop_size_A,
-                        output_dim=self.opt.data_load_size,
-                        context_pixels=self.opt.data_online_context_pixels,
-                        load_size=self.opt.data_online_creation_load_size_A,
-                        get_crop_coordinates=True,
-                        fixed_mask_size=self.opt.data_online_fixed_mask_size,
-                    )
+                crop_coordinates = crop_image(
+                    cur_A_img_path,
+                    cur_A_label_path,
+                    mask_delta=mask_delta_A,
+                    mask_random_offset=self.opt.data_online_creation_mask_random_offset_A,
+                    crop_delta=0,
+                    mask_square=self.opt.data_online_creation_mask_square_A,
+                    crop_dim=self.opt.data_online_creation_crop_size_A,
+                    output_dim=self.opt.data_load_size,
+                    context_pixels=self.opt.data_online_context_pixels,
+                    load_size=self.opt.data_online_creation_load_size_A,
+                    get_crop_coordinates=True,
+                    fixed_mask_size=self.opt.data_online_fixed_mask_size,
+                    crop_center=True,
+                )
                 cur_A_img, cur_A_label, ref_A_bbox, A_ref_bbox_id = crop_image(
                     cur_A_img_path,
                     cur_A_label_path,
                     mask_delta=mask_delta_A,
                     mask_random_offset=self.opt.data_online_creation_mask_random_offset_A,
-                    crop_delta=self.opt.data_online_creation_crop_delta_A,
+                    crop_delta=0,
                     mask_square=self.opt.data_online_creation_mask_square_A,
                     crop_dim=self.opt.data_online_creation_crop_size_A,
                     output_dim=self.opt.data_load_size,


### PR DESCRIPTION
python3 -W ignore::UserWarning  train.py \
--dataroot  /path/to/dataset     \
--checkpoints_dir    /path/to/checkpoints  \
--name test_debug  \
--gpu_ids 3 \
--data_relative_paths   \
--model_type palette \
--data_dataset_mode  self_supervised_vid_mask_online  \
--train_batch_size 2  \
--train_iter_size 1  \
--test_batch_size 1  \
--data_num_threads  1  \
--model_input_nc 3 \
--model_output_nc 3 \
--data_relative_paths \
--train_G_ema \
--train_optim adamw \
--G_netG unet_vid   \
--data_online_creation_rand_mask_A \
--train_G_lr 0.0002 \
--dataaug_no_rotate \
--G_diff_n_timestep_train  7  \
--G_diff_n_timestep_test  3   \
--data_temporal_frame_step 1 \
--alg_diffusion_cond_image_creation    computed_sketch  \
--alg_diffusion_cond_computed_sketch_list canny \
--alg_diffusion_cond_sketch_canny_range 0 190 \
--alg_diffusion_vid_canny_dropout  0.3 0.7 \
--train_compute_metrics_test   \
--train_metrics_every 2  \
--train_metrics_list PSNR LPIPS SSIM \
--output_print_freq 1   \
--output_display_freq 1  \
--data_temporal_number_frames  8  \
--data_online_creation_crop_size_A 64  \
--data_online_creation_crop_size_B 32  \
--data_crop_size 32  \
--data_load_size 32   \
--data_online_creation_mask_square_A  \
--with_amp \
--with_tf32 \
~             