### PR TITLE
chore: diffusers update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ pytest-asyncio
 httpx
 black==24.2.0
 dists-pytorch
+huggingface-hub==0.25.2
 transformers
 diffusers==0.25.1
 peft


### PR DESCRIPTION
This is a temporary pin of the hf hub library, otherwise an update of diffusers is required, that fails the tests with img2img-turbo due to a bug in diffusers. The bug is going to be fixed (https://github.com/huggingface/diffusers/pull/9807), so this PR is a temporary fix to allow the CI to proceed in the meantime.