### PR TITLE
fix vid inference of canny in situation of regeneration and  cond_in

### DIFF
--- a/scripts/gen_vid_diffusion.py
+++ b/scripts/gen_vid_diffusion.py
@@ -610,18 +610,28 @@ def generate(
                 # apply canny to the bbox to avoid edges around cond image
                 img_tensor_canny = img_tensor[:, y0:y1, x0:x1]
                 mask_canny = mask[:, y0:y1, x0:x1]
+                canny = fill_img_with_canny(
+                    img_tensor_canny.unsqueeze(0),
+                    mask_canny.unsqueeze(0),
+                    low_threshold=alg_diffusion_sketch_canny_thresholds[0],
+                    high_threshold=alg_diffusion_sketch_canny_thresholds[1],
+                    low_threshold_random=alg_diffusion_sketch_canny_thresholds[0],
+                    high_threshold_random=alg_diffusion_sketch_canny_thresholds[1],
+                    select_canny=[select_canny_list[sequence_count]],
+                )
+
             else:
                 img_tensor_canny = img_tensor
                 mask_canny = mask
-            canny = fill_img_with_canny(
-                img_tensor_canny.unsqueeze(0),
-                mask_canny.unsqueeze(0),
-                low_threshold=alg_diffusion_sketch_canny_thresholds[0],
-                high_threshold=alg_diffusion_sketch_canny_thresholds[1],
-                low_threshold_random=alg_diffusion_sketch_canny_thresholds[0],
-                high_threshold_random=alg_diffusion_sketch_canny_thresholds[1],
-                select_canny=[select_canny_list[sequence_count]],
-            )
+                canny = fill_img_with_canny(
+                    img_tensor_canny.unsqueeze(0),
+                    mask_canny.unsqueeze(0),
+                    low_threshold=alg_diffusion_sketch_canny_thresholds[0],
+                    high_threshold=alg_diffusion_sketch_canny_thresholds[1],
+                    low_threshold_random=-1,
+                    high_threshold_random=-1,
+                    select_canny=[select_canny_list[sequence_count]],
+                )
             if cond_in:
                 # restore background
                 cond_image = img_tensor.unsqueeze(0).clone()


### PR DESCRIPTION
when do the inference type regeneration, the canny is the last frame of crop`
```
cd scripts/
python3  gen_vid_diffusion.py  \
--img_in  /data  \
--mask_in /data   \
--model_in_file  /path/to/model/latest_net_G_A.pth  \
--paths_in_file  /path/to/inference_paths.txt      \
--dir_out  /path/to/inference  \
--gpuid 0 \
```

when do the inference type cond_in, the canny is the edge of cond_in and can be adjusted:
```
cd scripts/
python3  gen_vid_diffusion.py  \
--img_in  /data  \
--mask_in /data   \
--model_in_file  /path/to/model/latest_net_G_A.pth  \
--paths_in_file  /path/to/inference_paths.txt      \
--dir_out  /path/to/inference  \
--cond_in  path/to/newimage.png  \
--alg_diffusion_sketch_canny_thresholds 40 100	\
--gpuid 0 \
```