### PR TITLE
fix: warn user about unknown command line options

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -93,10 +93,8 @@ class BaseOptions:
                         % (len(flat_json), ",".join(flat_json.keys()))
                     )  # it's not an error anymore because server launching is done with all of the options even those from other models, raising an error will lead to a server crash
         else:
-            if only_known:
-                opt, _ = parser.parse_known_args(args)
-            else:
-                opt = parser.parse_args(args)
+            # do not ignore unknown options here, they are actual errors in the command line
+            opt = parser.parse_args(args)
         return opt
 
     def _json_parse_known_args(self, parser, opt, json_args):

--- a/util/parser.py
+++ b/util/parser.py
@@ -22,6 +22,13 @@ def get_opt(main_opt, remaining_args):
         with open(main_opt.config_json, "r") as jsonf:
             train_json = flatten_json(json.load(jsonf))
 
+        # Save the config file when --save_config is passed
+        is_config_saved = False
+        if "save_config" in override_options_names:
+            is_config_saved = True
+            override_options_names.remove("save_config")
+            remaining_args.remove("--save_config")
+
         if not "--dataroot" in remaining_args:
             remaining_args += ["--dataroot", "unused"]
         # model_type is mandatory to load the correct options
@@ -29,12 +36,6 @@ def get_opt(main_opt, remaining_args):
         override_options_json = flatten_json(
             TrainOptions().parse_to_json(remaining_args)
         )
-
-        # Save the config file when --save_config is passed
-        is_config_saved = False
-        if "save_config" in override_options_names:
-            is_config_saved = True
-            override_options_names.remove("save_config")
 
         for name in override_options_names:
             train_json[name] = override_options_json[name]


### PR DESCRIPTION
Before this PR unknown command line options were ignored which made it hard to spot typos.

Note:
`train_config.json` is already saved by default
`--save_config` makes sense only if `--config_json` was used
https://github.com/jolibrain/joliGEN/blob/master/util/parser.py#L19-L37