### PR TITLE
Fix metric calculation bug for DDPM model

### DIFF
--- a/test.py
+++ b/test.py
@@ -59,7 +59,7 @@ def launch_testing(opt, main_opt):
             model.netG_A.denoise_fn.model.beta_schedule["test"][
                 "n_timestep"
             ] = main_opt.sampling_steps
-            if main.opt.model_type == "palette":
+            if opt.model_type == "palette":
                 set_new_noise_schedule(model.netG_A.denoise_fn.model, "test")
         if main_opt.sampling_method is not None:
             model.netG_A.set_new_sampling_method(main_opt.sampling_method)


### PR DESCRIPTION
Calculates the evaluation metric for the DDPM video and image generated model. While the command below runs for a single epoch, the code supports evaluation across multiple epochs for future analysis. The command line is as follows:

python3 test.py \
  --test_model_dir  path/to/dataset \
  --test_epoch   5 \   # epoch number you want to test
  --test_metrics_list PSNR LPIPS SSIM \
  --test_nb_img 10 \   # number of test images to use for metric calculation
  --test_batch_size 1 \
  --sampling_steps 10 \   # number of DDPM inference steps
  --test_seed 42  \
