### PR TITLE
fix: restore previous options behavior

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -93,8 +93,10 @@ class BaseOptions:
                         % (len(flat_json), ",".join(flat_json.keys()))
                     )  # it's not an error anymore because server launching is done with all of the options even those from other models, raising an error will lead to a server crash
         else:
-            # do not ignore unknown options here, they are actual errors in the command line
-            opt = parser.parse_args(args)
+            if only_known:
+                opt, _ = parser.parse_known_args(args)
+            else:
+                opt = parser.parse_args(args)
         return opt
 
     def _json_parse_known_args(self, parser, opt, json_args):

--- a/util/parser.py
+++ b/util/parser.py
@@ -22,13 +22,6 @@ def get_opt(main_opt, remaining_args):
         with open(main_opt.config_json, "r") as jsonf:
             train_json = flatten_json(json.load(jsonf))
 
-        # Save the config file when --save_config is passed
-        is_config_saved = False
-        if "save_config" in override_options_names:
-            is_config_saved = True
-            override_options_names.remove("save_config")
-            remaining_args.remove("--save_config")
-
         if not "--dataroot" in remaining_args:
             remaining_args += ["--dataroot", "unused"]
         # model_type is mandatory to load the correct options
@@ -36,6 +29,12 @@ def get_opt(main_opt, remaining_args):
         override_options_json = flatten_json(
             TrainOptions().parse_to_json(remaining_args)
         )
+
+        # Save the config file when --save_config is passed
+        is_config_saved = False
+        if "save_config" in override_options_names:
+            is_config_saved = True
+            override_options_names.remove("save_config")
 
         for name in override_options_names:
             train_json[name] = override_options_json[name]


### PR DESCRIPTION
This PR reverts the changes introduced by #750.

PR #750 does not work as expected:
- we cannot use options introduced by `modify_commandline_options`
- it passed the CI because we don't use the command line but the JSON configs