### PR TITLE
fix: debug when using Canny condition in DDPM model for inference

### DIFF
--- a/scripts/gen_single_image_diffusion.py
+++ b/scripts/gen_single_image_diffusion.py
@@ -582,6 +582,7 @@ def generate(
             high_threshold=alg_diffusion_sketch_canny_thresholds[1],
             low_threshold_random=-1,
             high_threshold_random=-1,
+            select_canny=[1],
         )
         if cond_in:
             # restore background


### PR DESCRIPTION
It works with the following command line:
```
cd scripts/
python3  gen_single_image_diffusion.py  \
--model_in_file  path/to/latest_net_G_A.pth  \
--gpuid 1 \
--img_in path/to/02723.png  \
--bbox_in path/to/02723.png.txt \
--dir_out  path/to/inference_output  \
--img_width 128 \
--img_height 128 \
--mask_delta 10 \
--alg_diffusion_cond_image_creation canny \
--alg_diffusion_sketch_canny_thresholds 100 400 \
--cond_in   path/to/cat.png \ 
```