### PR TITLE
feat(ml): enable DDIM inference schedule in DDPM training

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -253,6 +253,20 @@ fi
 ####### cm_vid diffusion tests
 echo "Running cm_vid diffusion training tests"
 python3 -m pytest --rootdir ${current_dir} -p no:cacheprovider -s "${current_dir}/../tests/test_run_cm_vid_diffusion_online.py" --dataroot "$TARGET_MASK_SEM_ONLINE_DIR"
+=======
+python3 -m pytest --rootdir ${current_dir} -p no:cacheprovider -s "${current_dir}/../tests/test_run_ddpm_infer_ddim_online.py" --dataroot "$TARGET_MASK_SEM_ONLINE_DIR"
+OUT=$?
+
+if [ $OUT != 0 ]; then
+    exit 1
+fi
+
+###### test vid palette
+echo "Running test vid palette train and ddim infer"
+python3 "${current_dir}/../test.py" \
+        --save_config \
+        --test_model_dir $DIR/joligen_utest_vid_palette/ \
+        --test_metrics_list SSIM PSNR LPIPS
 OUT=$?
 
 if [ $OUT != 0 ]; then

--- a/tests/test_run_ddpm_infer_ddim_online.py
+++ b/tests/test_run_ddpm_infer_ddim_online.py
@@ -1,0 +1,110 @@
+import sys
+import os
+from itertools import product
+
+import pytest
+import torch.multiprocessing as mp
+
+sys.path.append(sys.path[0] + "/..")
+import train
+from data import create_dataset_temporal
+from options.train_options import TrainOptions
+from scripts.gen_vid_diffusion import InferenceDiffusionOptions, inference
+
+json_like_dict = {
+    "name": "joligen_utest_vid",
+    "output_display_env": "joligen_utest_vid",
+    "output_display_id": 0,
+    "gpu_ids": "0",
+    "data_load_size": 64,
+    "data_crop_size": 64,
+    "data_online_creation_crop_size_A": 64,
+    "data_online_creation_crop_delta_A": 50,
+    "data_online_creation_mask_delta_A_ratio": [[0.2, 0.2]],
+    "data_online_creation_crop_size_B": 64,
+    "data_online_creation_crop_delta_B": 50,
+    "train_n_epochs": 1,
+    "train_n_epochs_decay": 0,
+    "data_max_dataset_size": 10,
+    "data_relative_paths": True,
+    "train_G_ema": True,
+    "dataaug_no_rotate": True,
+    "G_unet_mha_num_head_channels": 32,
+    "G_unet_mha_channel_mults": [1, 2, 4, 8],
+    "G_nblocks": 9,
+    "G_padding_type": "reflect",
+    "data_online_creation_rand_mask_A": True,
+    "train_export_jit": False,
+    "train_save_latest_freq": 10,
+    "G_diff_n_timestep_test": 4,
+    "train_batch_size": 1,
+    "data_temporal_number_frames": 8,
+    "data_temporal_frame_step": 1,
+    "G_diff_n_timestep_train": 2000,
+    "G_diff_n_timestep_test": 1000,
+    "alg_palette_ddim_num_steps": 500,
+    "alg_palette_sampling_method": "ddpm",
+    "alg_palette_ddim_eta": 0.5,
+    "alg_palette_sampling_method_test": "ddim",
+    "train_n_epochs": 5,
+    "train_n_epochs_decay": 5,
+    "alg_palette_sampling_steps_test": 100,
+}
+
+infer_options = {
+    "gpu_ids": "0",
+    "img_width": 64,
+    "img_height": 64,
+    "model_type": "palette",
+    "sampling_steps": 1000,
+    "alg_palette_ddim_num_steps": 800,
+    "sampling_method": "ddim",
+    "alg_palette_ddim_eta": 0.5,
+}
+
+models_diffusion = ["palette"]
+G_netG = ["unet_vid"]
+data_dataset_mode = ["self_supervised_vid_mask_online"]
+
+product_list = product(models_diffusion, G_netG, data_dataset_mode)
+
+
+def test_vid_diffusion_online(dataroot):
+    json_like_dict["dataroot"] = dataroot
+    json_like_dict["checkpoints_dir"] = "/".join(dataroot.split("/")[:-1])
+    with open(
+        os.path.join(
+            json_like_dict["checkpoints_dir"],
+            dataroot.split("/")[-1],
+            "trainA",
+            "paths.txt",
+        )
+    ) as paths_file:
+        line = paths_file.readline().strip().split(" ")
+        infer_options["img_in"] = os.path.join(json_like_dict["dataroot"], line[0])
+        infer_options["mask_in"] = os.path.join(json_like_dict["dataroot"], line[1])
+
+    for model, Gtype, dataset_mode in product_list:
+        json_like_dict_c = json_like_dict.copy()
+        json_like_dict_c["model_type"] = model
+        json_like_dict_c["name"] += "_" + model
+        json_like_dict_c["G_netG"] = Gtype
+        json_like_dict_c["data_dataset_mode"] = dataset_mode
+        opt = TrainOptions().parse_json(json_like_dict_c, save_config=True)
+        train.launch_training(opt)
+
+        # Inference
+        infer_options_c = infer_options.copy()
+        infer_options_c["model_in_file"] = os.path.join(
+            json_like_dict_c["checkpoints_dir"],
+            json_like_dict_c["name"],
+            "latest_net_G_A.pth",
+        )
+        infer_options_c["paths_in_file"] = os.path.join(
+            json_like_dict["dataroot"], "trainA", "paths.txt"
+        )
+        infer_options_c["dir_out"] = os.path.join(
+            json_like_dict_c["checkpoints_dir"], json_like_dict_c["name"]
+        )
+        opt = InferenceDiffusionOptions().parse_json(infer_options_c, save_config=False)
+        inference(opt)


### PR DESCRIPTION
 - [x]  unite test

works with command:
```
python3 -W ignore::UserWarning -W ignore::FutureWarning train.py \
        --dataroot   path/to/data/vid  \
        --checkpoints_dir   path/to/ckpt   \
        --name  ddpm_ddim_debug  \
        --gpu_ids 1  \
        --data_relative_paths   \
        --model_type palette \
        --data_dataset_mode  self_supervised_vid_mask_online  \
        --train_batch_size 3  \
        --train_iter_size 8  \
        --data_num_threads  16  \
        --train_G_ema \
        --train_optim adamw \
        --G_netG unet_vid   \
        --data_online_creation_rand_mask_A \
        --dataaug_no_rotate \ 
        --G_diff_n_timestep_test  1000  \
        --G_diff_n_timestep_train  2000  \
        --output_print_freq 10   \
        --G_unet_vid_max_sequence_length  8  \
        --output_display_freq 10000  \
        --data_temporal_number_frames  8  \
        --data_temporal_frame_step   1  \
        --data_crop_size 64 \
        --data_load_size 64  \
        --train_compute_metrics_test   \
        --train_metrics_every 10000  \
        --train_metrics_list PSNR LPIPS SSIM \
        --with_amp \
        --with_tf32 \
        --data_online_creation_crop_size_A 300 \
        --data_online_creation_crop_size_B  300  \
        --alg_palette_ddim_num_steps 40 \
        --alg_palette_sampling_method ddpm \
        --alg_palette_ddim_eta 0.5 \
        --sampling_method_test  ddim \
        --train_n_epochs 200  \
        --train_sampling_steps_test 100  \                                  
```
and inference works:
```
python3 -W ignore::UserWarning -W ignore::FutureWarning scripts/gen_vid_diffusion.py \
--img_in /data \
--bbox_in /data \
--model_in_file path/to/80_net_G_A.pth   \
--paths_in_file   path/to/paths.txt \
--dir_out   path/to/infer_ddim \
--sampling_steps 100  \
--alg_palette_ddim_num_steps 600 \
--sampling_method ddim \
--alg_palette_ddim_eta 0.5 \ 
--gpuid 1  \
```