### PR TITLE
fix(inference): prevent touching gpu_ids in config when using runtime

### DIFF
--- a/scripts/gen_vid_diffusion.py
+++ b/scripts/gen_vid_diffusion.py
@@ -71,7 +71,7 @@ def load_model(
     train_json_path = model_in_dir + "/train_config.json"
     with open(train_json_path, "r") as jsonf:
         train_json = json.load(jsonf)
-
+    train_json["gpu_ids"] = str(device.index)
     opt = TrainOptions().parse_json(train_json)
     opt.jg_dir = jg_dir
     if opt.data_online_creation_mask_random_offset_A != [0.0]:


### PR DESCRIPTION
During inference, the code was still reading and updating the` --gpu_ids` field from the training config JSON, even though the actual GPU `--gpuid` was provided at runtime via the inference command.
This could sometimes lead to out-of-memory errors if the GPUs listed in the training config were already occupied.
Since `--gpu_ids` is only relevant for training, inference should strictly use the GPU specified `--gpuid` at runtime.

Fix:
Inference now ignores the `--gpu_ids` field in the config and relies solely on the runtime-selected GPU `--gpuid`