### PR TITLE
Change default sampling method from ddim to ddpm

### DIFF
--- a/models/palette_model.py
+++ b/models/palette_model.py
@@ -60,7 +60,7 @@ class PaletteModel(BaseDiffusionModel):
         parser.add_argument(
             "--alg_palette_sampling_method_test",
             type=str,
-            default="ddim",
+            default="ddpm",
             help="Sampling method to use during the test phase in training. Equivalent to 'sampling_method' in inference.",
         )
 


### PR DESCRIPTION
This PR updates the default value of `--alg_palette_sampling_method_test` from **ddim** to **ddpm**.
- In training, we are using DDPM.
- To ensure consistency between training and testing phases, it is better to have DDPM as the default sampling method.
- DDIM can still be used by explicitly passing `--alg_palette_sampling_method_test ddim` during the training.
The command line works:
```
python3 -W ignore::UserWarning -W ignore::FutureWarning train.py \
        --dataroot   path/to/lv_vid  \
        --checkpoints_dir  path/to/ckpt   \
        --name  ddpm_vid128_0923_continue  \
	--gpu_ids 2  \
        --data_relative_paths   \
        --model_type palette \
        --data_dataset_mode  self_supervised_vid_mask_online  \
        --train_batch_size 1  \
        --train_iter_size 16  \
        --data_num_threads  16  \
        --train_G_ema \
        --train_optim adamw \
        --G_netG unet_vid   \
        --data_online_creation_rand_mask_A \
        --dataaug_no_rotate \
        --G_diff_n_timestep_train  2000  \
        --G_diff_n_timestep_test   1000  \
	--output_print_freq 10   \
        --output_display_freq 8000  \
        --data_temporal_number_frames  6  \
        --data_temporal_frame_step   1  \
        --data_crop_size 128 \
        --data_load_size 128  \
        --train_compute_metrics_test   \
        --train_metrics_every 8000  \
        --train_metrics_list PSNR LPIPS SSIM \
        --with_amp \
        --with_tf32 \
	--data_online_creation_crop_size_A 300 \
        --data_online_creation_crop_size_B  300  \
	--train_save_epoch_freq 1  \
	--train_continue  \
	--alg_palette_sampling_method ddpm \
	--alg_palette_ddim_eta 0.5 \
	--alg_palette_ddim_num_steps 40 \
	--alg_palette_sampling_method_test  ddpm \
	--alg_palette_sampling_steps_test 1000  \
	--train_G_lr 0.00002   \
```
