### PR TITLE
fix(ml): correct else indentation for no-condition training in CM model

### DIFF
--- a/models/cm_model.py
+++ b/models/cm_model.py
@@ -421,8 +421,8 @@ class CMModel(BaseDiffusionModel):
                     )
                     name = "output_" + str(i + 1)
                     setattr(self, name, self.output)
-        else:
-            self.output = netG.restoration(y_t, y_cond, sampling_sigmas, mask)
+            else:
+                self.output = netG.restoration(y_t, y_cond, sampling_sigmas, mask)
 
         self.fake_B = self.output
         self.visuals = self.output


### PR DESCRIPTION
Fixes a logic error in the CM model that broke "no-condition" training. The `else` block was incorrectly indented,which caused the inference function to skip the `netG.restoration` step. As a result, the model produced no output when running without condition inputs.