### PR TITLE
feat(ml): add option to restrict PSNR and SSIM computation to dilated masked zones

### DIFF
--- a/models/palette_model.py
+++ b/models/palette_model.py
@@ -21,6 +21,8 @@ from models.modules.diffusion_utils import (
     rearrange_4dto5d_bf,
     set_new_noise_schedule,
 )
+from torchvision.ops import masks_to_boxes
+import torch.nn.functional as F
 
 
 class PaletteModel(BaseDiffusionModel):
@@ -71,6 +73,11 @@ class PaletteModel(BaseDiffusionModel):
             help="Autoregressive training: each batch is either all canny edges(noisy image) or one full image with others black.",
         )
 
+        parser.add_argument(
+            "--alg_palette_metric_mask",
+            action="store_true",
+            help="Evaluate the metric PSNR and SSIM on the dilated mask region instead of the cropped image.",
+        )
         if is_train:
             parser = PaletteModel.modify_commandline_options_train(parser)
 
@@ -724,6 +731,50 @@ class PaletteModel(BaseDiffusionModel):
                     ddim_num_steps=self.ddim_num_steps,
                     ddim_eta=self.ddim_eta,
                 )
+                ## dilated_mask metric
+                if self.opt.G_netG == "unet_vid" and self.opt.alg_palette_metric_mask:
+                    B, T, C, H, W = mask.shape
+                    (mask_4d,) = rearrange_5dto4d_bf(mask)
+                    dilation = 3
+                    dilated_mask_4d = F.max_pool2d(
+                        mask_4d.float(),
+                        kernel_size=2 * dilation + 1,
+                        stride=1,
+                        padding=dilation,
+                    )
+                    dilated_mask_4d = (dilated_mask_4d > 0.5).float()
+                    (dilated_mask,) = rearrange_4dto5d_bf(T, dilated_mask_4d)
+
+                    dilated_mask_expanded = dilated_mask.expand_as(self.output)
+                    self.fake_B_dilated = self.output * dilated_mask_expanded
+                    self.gt_image_dilated = self.gt_image * dilated_mask_expanded
+
+                    B, T, _, H, W = dilated_mask.shape
+                    boxes = masks_to_boxes(dilated_mask.view(-1, H, W)).int()
+
+                    fake_crops = [
+                        [
+                            self.fake_B_dilated[b, t, :, y0:y1, x0:x1]
+                            for t, (x0, y0, x1, y1) in enumerate(
+                                boxes[b * T : (b + 1) * T]
+                            )
+                        ]
+                        for b in range(B)
+                    ]
+
+                    gt_crops = [
+                        [
+                            self.gt_image_dilated[b, t, :, y0:y1, x0:x1]
+                            for t, (x0, y0, x1, y1) in enumerate(
+                                boxes[b * T : (b + 1) * T]
+                            )
+                        ]
+                        for b in range(B)
+                    ]
+
+                    self.fake_B_dilated = fake_crops
+                    self.gt_image_dilated = gt_crops
+
                 self.fake_B = self.output
         # task: super resolution, pix2pix
         elif self.task in ["super_resolution", "pix2pix"]:


### PR DESCRIPTION
This PR introduces a new configuration option, `--alg_palette_metric_mask`, that allows PSNR and SSIM to be computed only within dilated masked regions.
When enabled, metric evaluation focuses exclusively on the inpainted zones — the parts of the image actually generated by the model.

The command line:
```
python3 -W ignore::UserWarning -W ignore::FutureWarning train.py \
        --dataroot     path/to/vid  \
        --checkpoints_dir   path/to/ckpt   \
        --name  ddpm_debug  \
        --gpu_ids 1  \
        --data_relative_paths   \
        --model_type palette \
        --data_dataset_mode  self_supervised_vid_mask_online  \
        --train_batch_size 1  \
        --test_batch_size  2 \
        --train_iter_size 1  \
        --data_num_threads  1  \
        --train_G_ema \
        --train_optim adamw \
        --G_netG unet_vid   \
        --data_online_creation_rand_mask_A \
        --dataaug_no_rotate \
        --G_diff_n_timestep_train  20  \
        --G_diff_n_timestep_test   10  \
        --output_print_freq 1   \
        --output_display_freq 1 \
        --data_temporal_number_frames  3  \
        --data_temporal_frame_step   1  \
        --data_crop_size 128 \
        --data_load_size 128  \
        --train_compute_metrics_test   \
        --train_metrics_every 1  \
        --train_metrics_list PSNR LPIPS SSIM \
        --with_amp \
        --with_tf32 \
        --data_online_creation_crop_size_A 300 \
        --data_online_creation_crop_size_B  300  \
        --train_save_epoch_freq 1000  \
        --alg_palette_sampling_method ddpm \
        --alg_palette_ddim_eta 0.5 \
        --alg_palette_ddim_num_steps 40 \
        --alg_palette_sampling_method_test  ddpm \
        --alg_palette_sampling_steps_test 10  \
        --train_G_lr 0.00002   \
        --alg_palette_metric_mask  \
```