### PR TITLE
feat(ml): add option to restrict PSNR and SSIM computation to dilated masked zones for consistency model

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -1638,7 +1638,10 @@ class BaseModel(ABC):
             real_tensor, fake_tensor = rearrange_5dto4d_bf(real_tensor, fake_tensor)
             ssim_test = ssim(real_tensor, fake_tensor)
             psnr_test = psnr(real_tensor, fake_tensor)
-            if self.opt.alg_palette_metric_mask:
+            if getattr(self.opt, "alg_palette_metric_mask", False) or getattr(
+                self.opt, "alg_cm_metric_mask", False
+            ):
+                # if self.opt.alg_palette_metric_mask or self.opt.alg_cm_metric_mask:
                 logging.warning(
                     "LPIPS metric is not supported when using a dilated mask zone."
                 )
@@ -1656,6 +1659,7 @@ class BaseModel(ABC):
                         n += 1
                 psnr_test = psnr_sum / n if n else 0
                 ssim_test = ssim_sum / n if n else 0
+
         else:
             ssim_test = ssim(real_tensor, fake_tensor)
             psnr_test = psnr(real_tensor, fake_tensor)


### PR DESCRIPTION
This PR introduces a new configuration option, --alg_cm_metric_mask, that allows PSNR and SSIM to be computed only within dilated masked regions.
When enabled, metric evaluation focuses exclusively on the inpainted zones — the parts of the image actually generated by the model.

The command line:
```
python3 -W ignore::UserWarning -W ignore::FutureWarning train.py \
        --dataroot     path/to/dataset/vid  \
        --checkpoints_dir   path/to/ckpt   \
        --name  cm_debug  \
        --gpu_ids 0  \
        --data_relative_paths   \
        --model_type cm  \
        --data_dataset_mode  self_supervised_vid_mask_online  \
        --train_batch_size 1  \
        --test_batch_size  1 \
        --train_iter_size 1  \
        --data_num_threads  1  \
        --train_G_ema \
        --train_optim adamw \
        --G_netG unet_vid   \
        --data_online_creation_rand_mask_A \
        --dataaug_no_rotate \
        --output_print_freq 1   \
        --output_display_freq 1 \
        --data_temporal_number_frames  6  \
        --data_temporal_frame_step   1  \
        --data_crop_size 64 \
        --data_load_size 64  \
        --train_compute_metrics_test   \
        --train_metrics_every 1  \
        --train_metrics_list PSNR LPIPS SSIM \
        --with_amp \
        --with_tf32 \
        --data_online_creation_crop_size_A 300 \
        --data_online_creation_crop_size_B  300  \
        --train_save_epoch_freq 1000  \
        --train_G_lr 0.00002   \
        --alg_cm_metric_mask  \
```