### PR TITLE
feat: continue cls inference updates

### DIFF
--- a/scripts/gen_vid_autoregressive_diffusion_forward_NoCanny_online_progress_cls.py
+++ b/scripts/gen_vid_autoregressive_diffusion_forward_NoCanny_online_progress_cls.py
@@ -435,7 +435,7 @@ def generate_streaming(
                         out.write(json.dumps(generated_bbox))
 
         video_frame = (
-            np.concatenate([img_orig, out_img_real_size], axis=1)
+            np.concatenate([out_img_real_size, img_orig], axis=1)
             if compare
             else out_img_real_size
         )
@@ -1201,7 +1201,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--compare",
         action="store_true",
-        help="Put the original frame on the left side of the generated frame in the AVI output",
+        help="Put the generated frame on the left side of the original frame in the AVI output",
     )
     extra_args, _ = parser.parse_known_args()
     args.compare = extra_args.compare

--- a/util/util.py
+++ b/util/util.py
@@ -150,7 +150,7 @@ def display_mask(mask):
     mask_dis = np.zeros((mask.shape[0], mask.shape[1], 3))
     # print('mask_dis shape',mask_dis.shape)
     for i in range(mask.shape[0]):
-        for j in range(mask.shape[0]):
+        for j in range(mask.shape[1]):
             cls_display = mask[i, j] % nb_cls_display
             mask_dis[i, j, :] = dict_col[cls_display]
     return mask_dis


### PR DESCRIPTION
update the inference generation. when use `--compare`, left is the generated video, and right is the origin video