### PR TITLE
feat(ml):test muon optimizer for b2b_vid_cls

### DIFF
--- a/options/train_options.py
+++ b/options/train_options.py
@@ -198,7 +198,7 @@ class TrainOptions(CommonOptions):
         parser.add_argument(
             "--train_optim",
             default="adam",
-            choices=["adam", "radam", "adamw", "lion", "adam8bit"],
+            choices=["adam", "radam", "adamw", "lion", "adam8bit", "muon"],
             help="optimizer (adam, radam, adamw, ...)",
         )
         parser.add_argument(

--- a/train.py
+++ b/train.py
@@ -18,8 +18,6 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 
-import bitsandbytes as bnb
-
 from data import (
     create_dataloader,
     create_dataset,
@@ -33,6 +31,74 @@ from util.visualizer import Visualizer
 from util.lion_pytorch import Lion
 from util.script import get_override_options_names
 import datetime
+
+
+class MuonWithAdamW(torch.optim.Optimizer):
+    def __init__(self, params, lr, betas, weight_decay, eps):
+        params = list(params)
+        defaults = {"lr": lr, "weight_decay": weight_decay}
+        super().__init__(params, defaults)
+
+        muon_params = [p for p in params if p.requires_grad and p.ndim == 2]
+        adamw_params = [p for p in params if p.requires_grad and p.ndim != 2]
+
+        self.optimizers = []
+        if muon_params:
+            self.optimizers.append(
+                torch.optim.Muon(
+                    muon_params,
+                    lr=lr,
+                    weight_decay=weight_decay,
+                    momentum=betas[0],
+                    eps=eps,
+                    adjust_lr_fn="match_rms_adamw",
+                )
+            )
+        if adamw_params:
+            self.optimizers.append(
+                torch.optim.AdamW(
+                    adamw_params,
+                    lr=lr,
+                    betas=betas,
+                    weight_decay=weight_decay,
+                    eps=eps,
+                )
+            )
+
+        self.param_groups = [
+            group for optimizer in self.optimizers for group in optimizer.param_groups
+        ]
+        print(
+            "Muon params:",
+            sum(p.numel() for p in muon_params),
+            "/ AdamW fallback params:",
+            sum(p.numel() for p in adamw_params),
+        )
+
+    def zero_grad(self, set_to_none=True):
+        for optimizer in self.optimizers:
+            optimizer.zero_grad(set_to_none=set_to_none)
+
+    def step(self, closure=None):
+        loss = None
+        for i, optimizer in enumerate(self.optimizers):
+            if i == 0 and closure is not None:
+                loss = optimizer.step(closure)
+            else:
+                optimizer.step()
+        return loss
+
+    def state_dict(self):
+        return {"optimizers": [optimizer.state_dict() for optimizer in self.optimizers]}
+
+    def load_state_dict(self, state_dict):
+        for optimizer, optimizer_state in zip(
+            self.optimizers, state_dict["optimizers"]
+        ):
+            optimizer.load_state_dict(optimizer_state)
+        self.param_groups = [
+            group for optimizer in self.optimizers for group in optimizer.param_groups
+        ]
 
 
 def setup(rank, world_size, port):
@@ -59,7 +125,18 @@ def optim(opt, params, lr, betas, weight_decay, eps):
     elif opt.train_optim == "lion":
         return Lion(params, lr, betas, weight_decay)
     elif opt.train_optim == "adam8bit":
+        import bitsandbytes as bnb
+
         return bnb.optim.Adam8bit(params, lr, betas, weight_decay=weight_decay, eps=eps)
+    elif opt.train_optim == "muon":
+        if not hasattr(torch.optim, "Muon"):
+            raise RuntimeError(
+                "torch.optim.Muon is not available in this Python environment. "
+                f"Current torch version is {torch.__version__}. "
+                "Run training with a PyTorch build that provides torch.optim.Muon "
+                "or switch --train_optim back to adamw."
+            )
+        return MuonWithAdamW(params, lr, betas, weight_decay, eps)
 
 
 def get_current_b2b_validation_loss(model, test_names):


### PR DESCRIPTION
## Summary
  - Add Muon optimizer support for `b2b_vid_cls`.
  - Allow Muon to be selected from training options.
  - Update optimizer setup for Muon.

## Command line
```
python3 -W ignore::FutureWarning -W ignore::UserWarning train.py \
--dataroot   path/to/dataset_vid  \
--data_relative_paths   \
--data_num_threads  4  \
--data_dataset_mode self_supervised_vid_labeled_mask_cls_online \
--data_load_size 256   \
--data_crop_size 256   \
--data_online_creation_crop_size_A 256 \
--data_online_creation_crop_delta_A  25 \
--data_online_creation_rand_mask_A \
--data_online_creation_mask_random_offset_A  0.1 0.1  \
--data_temporal_number_frames  2  \
--data_temporal_frame_step   1  \
--dataaug_flip both  \
--dataaug_diff_aug_policy color \
--dataaug_diff_aug_proba 1.0 \
--model_type  b2b   \
--model_input_nc 3 \
--model_output_nc 3 \
--G_netG vit_vid \
--G_vit_variant "JiTVid-B/16" \
--G_vit_disable_bottleneck \
--gpu_ids  1  \
--name   test_vid256_b2b_muon  \
--train_batch_size 10 \
--train_iter_size 2  \
--train_n_epochs 60000  \
--train_save_epoch_freq  10  \
--train_G_ema \
--train_optim  muon \
--train_G_lr 5e-4 \
--train_optim_weight_decay 0.0 \
--train_beta1 0.9 \
--train_beta2 0.95 \
--train_compute_metrics_test   \
--train_metrics_list PSNR    \
--train_metrics_every 8000  \
--test_batch_size 2 \
--with_amp \
--with_tf32 \
--with_torch_compile  \
--output_print_freq 200   \
--output_display_freq 4000  \
--alg_b2b_denoise_timesteps 2 5 20   \
--alg_b2b_cfg_scale 1.0 \
--alg_b2b_disable_inference_clipping \
--alg_b2b_loss_masked_region_only \
--alg_b2b_perceptual_loss LPIPS DISTS \
--alg_b2b_lambda_perceptual 0.1 \
--alg_b2b_loss pseudo_huber  \
--alg_b2b_autoregressive \
--alg_b2b_use_gt_prob 0.2 \
--alg_b2b_mask_as_channel  \
--G_vit_num_classes  3 \
--f_s_semantic_nclasses 3 \
```