### PR TITLE
fix: preserve semantic colors in B2B mask visuals

### DIFF
--- a/models/b2b_model.py
+++ b/models/b2b_model.py
@@ -78,7 +78,7 @@ class B2BModel(BaseDiffusionModel):
         )
 
     def _b2b_visual_mask_tensor(self, name, mask):
-        if "augmented_mask" in name:
+        if name in {"mask_", "augmented_mask_"}:
             return self._b2b_class_mask_visual_tensor(mask)
         return self._b2b_mask_visual_tensor(mask)
 

--- a/tests/test_b2b_mask_visualization.py
+++ b/tests/test_b2b_mask_visualization.py
@@ -1,0 +1,30 @@
+import torch
+
+from models.b2b_model import B2BModel
+from util.util import tensor2im
+
+
+def test_b2b_semantic_mask_visual_uses_class_palette():
+    model = B2BModel.__new__(B2BModel)
+    mask = torch.tensor([[[[0, 1], [2, 0]]]], dtype=torch.int64)
+
+    for name in ("mask_", "augmented_mask_"):
+        visual = model._b2b_visual_mask_tensor(name, mask)
+
+        assert visual.shape == (1, 2, 2)
+        assert torch.equal(visual, mask.squeeze(0))
+        assert tensor2im(visual).tolist() == [
+            [[0, 0, 0], [0, 255, 0]],
+            [[255, 0, 0], [0, 0, 0]],
+        ]
+
+
+def test_b2b_predicted_mask_visual_stays_binary():
+    model = B2BModel.__new__(B2BModel)
+    mask = torch.tensor([[[[-1.0, 0.0], [0.25, 1.0]]]])
+
+    visual = model._b2b_visual_mask_tensor("predicted_mask_2_steps_", mask)
+    expected = (mask > 0).float().repeat(1, 3, 1, 1) * 2.0 - 1.0
+
+    assert visual.shape == (1, 3, 2, 2)
+    assert torch.equal(visual, expected)


### PR DESCRIPTION
 ## Summary

  - Display the regular B2B `mask_` visual using the existing semantic class palette.
  - Keep target and predicted mask visuals binary.
  - Add focused regression tests for both behaviors.

  ## Problem

  B2B masks can contain semantic class IDs, but the normal Visdom mask visualization converted
  every positive value using:

  ```python
  mask = mask > 0
  ```

  As a result, class 1 and class 2 were both displayed as white, even though the underlying
  mask tensor preserved their class IDs.

  ## Solution

  Route the normal mask_ visual through the existing class-mask visualization path, which
  preserves semantic IDs before tensor2im() applies the color palette.

  For example:

  - Background 0: black
  - Class 1: green
  - Class 2: red

  Predicted and target masks remain binary black/white visuals.

  ## Impact

  This is a visualization-only change. It does not modify:

  - Dataset preprocessing
  - Model inputs
  - Training losses
  - Inference behavior
  - Checkpoint compatibility
  

  ## Tests

 python3 -m pytest \
    -p no:cacheprovider tests/test_b2b_mask_visualization.py -q

  Result: 2 passed

  python3 -m black --check \
    models/b2b_model.py tests/test_b2b_mask_visualization.py

  Result: both files left unchanged.

