### PR TITLE
fix: evaluate all video test batches for metrics

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -1948,11 +1948,6 @@ class BaseModel(ABC):
 
             if len(fake_list) >= self.opt.train_nb_img_max_fid:
                 break
-            if (
-                self.opt.G_netG in ["unet_vid", "vit_vid"]
-                and i < self.opt.test_batch_size
-            ):
-                break
 
         if compute_b2b_val_loss:
             if b2b_val_loss_count > 0:

--- a/tests/test_video_metrics.py
+++ b/tests/test_video_metrics.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+import torch
+
+import models.base_model as base_model_module
+from models.base_model import BaseModel
+from util.util import MAX_INT
+
+
+class VideoMetricModel:
+    def __init__(self):
+        self.opt = SimpleNamespace(
+            train_nb_img_max_fid=MAX_INT,
+            model_type="palette",
+            isTrain=True,
+            test_batch_size=2,
+            G_netG="vit_vid",
+            data_direction="AtoB",
+            train_metrics_list=["PSNR"],
+        )
+        self.use_temporal = False
+        self.use_inception = False
+        self.visual_names = []
+        self.inference_offsets = []
+
+    def _is_b2b_validation_loss_enabled(self):
+        return False
+
+    def set_input(self, data):
+        self.gt_image = data
+
+    def inference(self, _batch_size, offset=0):
+        self.inference_offsets.append(offset)
+        self.fake_B = self.gt_image.clone()
+
+
+def test_video_metrics_process_every_test_batch(monkeypatch):
+    monkeypatch.setattr(
+        base_model_module, "ssim", lambda _real, _fake: torch.tensor(1.0)
+    )
+
+    def fake_psnr(real, _fake, reduction="mean"):
+        if reduction == "none":
+            return torch.ones(real.shape[0])
+        return torch.tensor(1.0)
+
+    monkeypatch.setattr(base_model_module, "psnr", fake_psnr)
+
+    model = VideoMetricModel()
+    test_batches = [
+        (torch.zeros(2, 2, 3, 4, 4),),
+        (torch.zeros(2, 2, 3, 4, 4),),
+        (torch.zeros(1, 2, 3, 4, 4),),
+    ]
+
+    BaseModel.compute_metrics_test(model, test_batches, n_epoch=1, n_iter=8000)
+
+    assert model.inference_offsets == [0, 2, 4]


### PR DESCRIPTION
 ## Context

  For `unet_vid` and `vit_vid`, test metrics stop after the first test batch.

  Inside `compute_metrics_test`, `i` is reset to `0` and is not incremented in the video branch. Therefore, this condition is always true when `test_batch_size > 0`:

  if self.opt.G_netG in ["unet_vid", "vit_vid"] and i < self.opt.test_batch_size:
      break

  For example, with --test_batch_size 2, metrics are computed on only the first two test samples instead of the complete testA dataset.

  ## Changes

  - Remove the video-specific early break.
  - Let the finite test dataloader iterate through every test batch.
  - Keep --train_nb_img_max_fid as the explicit metric sample limit.
  - Add a regression test covering multiple batches and a partial final batch.

