### PR TITLE
fix: mask B2B PSNR and cover temporal tests

### DIFF
--- a/data/self_supervised_vid_labeled_mask_cls_online_dataset.py
+++ b/data/self_supervised_vid_labeled_mask_cls_online_dataset.py
@@ -22,6 +22,7 @@ from data.temporal_sampling import (
     TemporalFrameStepMixin,
     build_temporal_series_index,
     select_temporal_start_from_series,
+    select_temporal_start_from_series_at_index,
 )
 from util.b2b_context import b2b_global_context_enabled_from_opt
 
@@ -40,6 +41,12 @@ class SelfSupervisedVidLabeledMaskClsOnlineDataset(TemporalFrameStepMixin, BaseD
         As we have two datasets with potentially different number of images,
         we take a maximum of
         """
+        if (
+            self.phase == "test"
+            and not self._random_temporal_frame_step_enabled()
+            and hasattr(self, "cumulative_sums")
+        ):
+            return self.cumulative_sums[-1] if self.cumulative_sums else 0
         if hasattr(self, "B_img_paths"):
             return max(self.A_size, self.B_size)
         else:
@@ -88,19 +95,28 @@ class SelfSupervisedVidLabeledMaskClsOnlineDataset(TemporalFrameStepMixin, BaseD
             self.A_img_paths, self.num_frames, self.frame_step
         )
 
-    def _select_temporal_index_A(self, frame_step):
+    def _select_temporal_index_A(self, frame_step, dataset_index=None):
         if not self._random_temporal_frame_step_enabled():
-            if len(self.frames_counts) == 1:  # single video mario
-                if self.range_A == 0:
-                    return 0
-                return random.randint(0, self.range_A - 1)
-
             series_index = (
                 self.vid_series_paths,
                 self.frames_counts,
                 self.cumulative_sums,
                 self.available_frame_pool,
             )
+            if self.phase == "test":
+                if dataset_index is None:
+                    raise ValueError(
+                        "test temporal sampling requires the dataset index"
+                    )
+                return select_temporal_start_from_series_at_index(
+                    self.A_img_paths, series_index, dataset_index
+                )
+
+            if len(self.frames_counts) == 1:  # single video mario
+                if self.range_A == 0:
+                    return 0
+                return random.randint(0, self.range_A - 1)
+
             return select_temporal_start_from_series(self.A_img_paths, series_index)
 
         if len(self.vid_series_paths) == 1:
@@ -122,7 +138,7 @@ class SelfSupervisedVidLabeledMaskClsOnlineDataset(TemporalFrameStepMixin, BaseD
         index=None,
     ):  # all params are unused
         effective_frame_step = self._sample_temporal_frame_step()
-        index_A = self._select_temporal_index_A(effective_frame_step)
+        index_A = self._select_temporal_index_A(effective_frame_step, index)
         if index_A is None:
             return None
 

--- a/data/self_supervised_vid_mask_online_dataset.py
+++ b/data/self_supervised_vid_mask_online_dataset.py
@@ -22,6 +22,7 @@ from data.temporal_sampling import (
     TemporalFrameStepMixin,
     build_temporal_series_index,
     select_temporal_start_from_series,
+    select_temporal_start_from_series_at_index,
 )
 from util.b2b_context import b2b_global_context_enabled_from_opt
 
@@ -40,6 +41,12 @@ class SelfSupervisedVidMaskOnlineDataset(TemporalFrameStepMixin, BaseDataset):
         As we have two datasets with potentially different number of images,
         we take a maximum of
         """
+        if (
+            self.phase == "test"
+            and not self._random_temporal_frame_step_enabled()
+            and hasattr(self, "cumulative_sums")
+        ):
+            return self.cumulative_sums[-1] if self.cumulative_sums else 0
         if hasattr(self, "B_img_paths"):
             return max(self.A_size, self.B_size)
         else:
@@ -87,19 +94,28 @@ class SelfSupervisedVidMaskOnlineDataset(TemporalFrameStepMixin, BaseDataset):
             self.A_img_paths, self.num_frames, self.frame_step
         )
 
-    def _select_temporal_index_A(self, frame_step):
+    def _select_temporal_index_A(self, frame_step, dataset_index=None):
         if not self._random_temporal_frame_step_enabled():
-            if len(self.frames_counts) == 1:  # single video mario
-                if self.range_A == 0:
-                    return 0
-                return random.randint(0, self.range_A - 1)
-
             series_index = (
                 self.vid_series_paths,
                 self.frames_counts,
                 self.cumulative_sums,
                 self.available_frame_pool,
             )
+            if self.phase == "test":
+                if dataset_index is None:
+                    raise ValueError(
+                        "test temporal sampling requires the dataset index"
+                    )
+                return select_temporal_start_from_series_at_index(
+                    self.A_img_paths, series_index, dataset_index
+                )
+
+            if len(self.frames_counts) == 1:  # single video mario
+                if self.range_A == 0:
+                    return 0
+                return random.randint(0, self.range_A - 1)
+
             return select_temporal_start_from_series(self.A_img_paths, series_index)
 
         if len(self.vid_series_paths) == 1:
@@ -122,7 +138,7 @@ class SelfSupervisedVidMaskOnlineDataset(TemporalFrameStepMixin, BaseDataset):
     ):  # all params are unused
 
         effective_frame_step = self._sample_temporal_frame_step()
-        index_A = self._select_temporal_index_A(effective_frame_step)
+        index_A = self._select_temporal_index_A(effective_frame_step, index)
         if index_A is None:
             return None
 

--- a/data/temporal_sampling.py
+++ b/data/temporal_sampling.py
@@ -53,31 +53,43 @@ def build_temporal_series_index(paths, num_frames, frame_step):
     return vid_series_paths, frames_counts, cumulative_sums, available_frame_pool
 
 
+def select_temporal_start_from_series_at_index(paths, series_index, start_index):
+    """Map a valid-window ordinal to its first frame in ``paths``."""
+    vid_series_paths, _frames_counts, cumulative_sums, _available_frame_pool = (
+        series_index
+    )
+    if not cumulative_sums or cumulative_sums[-1] <= 0:
+        return None
+
+    total_starts = cumulative_sums[-1]
+    if start_index < 0 or start_index >= total_starts:
+        raise IndexError(
+            f"temporal start index {start_index} is outside [0, {total_starts})"
+        )
+
+    selected_index = next(
+        index
+        for index, cumulative_sum in enumerate(cumulative_sums)
+        if start_index < cumulative_sum
+    )
+    selected_vid = vid_series_paths[selected_index]
+    previous_sum = cumulative_sums[selected_index - 1] if selected_index > 0 else 0
+    frame_num = start_index - previous_sum
+
+    filtered_paths = [path for path in paths if os.path.dirname(path) == selected_vid]
+    selected_path = filtered_paths[frame_num]
+    return paths.index(selected_path)
+
+
 def select_temporal_start_from_series(paths, series_index):
-    vid_series_paths, _frames_counts, cumulative_sums, available_frame_pool = (
+    _vid_series_paths, _frames_counts, cumulative_sums, _available_frame_pool = (
         series_index
     )
     if not cumulative_sums or cumulative_sums[-1] <= 0:
         return None
 
     random_start = random.randint(0, cumulative_sums[-1] - 1)
-    selected_index = [
-        i
-        for i, frame_pool in enumerate(available_frame_pool)
-        if random_start in frame_pool
-    ]
-    if len(selected_index) != 1:
-        raise ValueError("random temporal start not found in any video series")
-    selected_index = selected_index[0]
-    selected_vid = vid_series_paths[selected_index]
-    if selected_index > 0:
-        frame_num = random_start - cumulative_sums[selected_index - 1]
-    else:
-        frame_num = random_start
-
-    filtered_paths = [path for path in paths if os.path.dirname(path) == selected_vid]
-    selected_path = filtered_paths[frame_num]
-    return paths.index(selected_path)
+    return select_temporal_start_from_series_at_index(paths, series_index, random_start)
 
 
 class TemporalFrameStepMixin:

--- a/models/b2b_model.py
+++ b/models/b2b_model.py
@@ -333,7 +333,7 @@ class B2BModel(BaseDiffusionModel):
         parser.add_argument(
             "--alg_b2b_metric_mask",
             action="store_true",
-            help="Evaluate metrics only on dilated mask region",
+            help="Evaluate B2B PSNR over the exact input mask instead of the full crop",
         )
 
         if is_train:

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -1721,19 +1721,72 @@ class BaseModel(ABC):
 
         return metrics
 
-    def _compute_metrics(self, fake_images, gt_images, filter_psnr_78=False):
+    @staticmethod
+    def _compute_masked_psnr(real, fake, mask, filter_psnr_78=False):
+        """Average per-image PSNR over non-empty binary mask regions."""
+        if real.shape != fake.shape:
+            raise ValueError(
+                f"Masked PSNR expects matching images, got {real.shape} and "
+                f"{fake.shape}."
+            )
+        if mask.ndim == real.ndim - 1:
+            mask = mask.unsqueeze(1)
+        if mask.ndim != real.ndim or mask.shape[0] != real.shape[0]:
+            raise ValueError(
+                f"Masked PSNR expects a mask matching the image batch, got "
+                f"{mask.shape} for {real.shape}."
+            )
+        if mask.shape[2:] != real.shape[2:]:
+            raise ValueError(
+                f"Masked PSNR expects matching spatial dimensions, got "
+                f"{mask.shape[2:]} and {real.shape[2:]}."
+            )
+
+        mask = (mask > 0).to(device=real.device, dtype=real.dtype)
+        if mask.shape[1] == 1 and real.shape[1] != 1:
+            mask = mask.expand(-1, real.shape[1], *([-1] * (real.ndim - 2)))
+        elif mask.shape[1] != real.shape[1]:
+            raise ValueError(
+                f"Masked PSNR expects one or {real.shape[1]} mask channels, got "
+                f"{mask.shape[1]}."
+            )
+
+        reduce_dims = tuple(range(1, real.ndim))
+        pixel_count = mask.sum(dim=reduce_dims)
+        valid = pixel_count > 0
+        if not valid.any():
+            return real.new_tensor(0.0)
+
+        squared_error = ((real - fake) ** 2 * mask).sum(dim=reduce_dims)
+        mse = squared_error[valid] / pixel_count[valid]
+        psnr_values = -10.0 * torch.log10(mse.clamp_min(1e-8))
+
+        if filter_psnr_78:
+            filtered = psnr_values[psnr_values < 78]
+            if filtered.numel() > 0:
+                psnr_values = filtered
+        return psnr_values.mean()
+
+    def _compute_metrics(
+        self, fake_images, gt_images, filter_psnr_78=False, masks=None
+    ):
         compute_lpips = hasattr(self, "lpips_metric")
         compute_dinov2 = hasattr(self, "dinov2_metric")
         psnr_vals = []
         ssim_sum, lpips_sum, dinov2_sum, n = 0.0, 0.0, 0.0, 0
-        for fake, gt in zip(fake_images, gt_images):
+        for index, (fake, gt) in enumerate(zip(fake_images, gt_images)):
             if fake.shape != gt.shape:
                 print(f"Skip mismatched shapes: {fake.shape} vs {gt.shape}")
                 continue
             fake = (fake.clamp(-1, 1).unsqueeze(0) + 1) / 2
             gt = (gt.clamp(-1, 1).unsqueeze(0) + 1) / 2
 
-            psnr_vals.append(psnr(fake, gt, data_range=1.0).item())
+            if masks is None:
+                psnr_vals.append(psnr(fake, gt, data_range=1.0).item())
+            elif (masks[index] > 0).any():
+                psnr_vals.append(
+                    self._compute_masked_psnr(gt, fake, masks[index]).item()
+                )
             ssim_sum += ssim(fake, gt).item()
 
             if compute_lpips:
@@ -1801,8 +1854,13 @@ class BaseModel(ABC):
 
         fake_list = []
         real_list = []
+        mask_list = []
         fake_list_per_step = {}
         real_list_per_step = {}
+        mask_list_per_step = {}
+        use_b2b_metric_mask = getattr(self.opt, "model_type", "") == "b2b" and getattr(
+            self.opt, "alg_b2b_metric_mask", False
+        )
         compute_b2b_val_loss = self._is_b2b_validation_loss_enabled()
         b2b_val_loss_sum = 0.0
         b2b_val_loss_count = 0
@@ -1854,6 +1912,34 @@ class BaseModel(ABC):
             finally:
                 self.opt.isTrain = istrain
 
+            batch_metric_masks = None
+            if use_b2b_metric_mask:
+                if not hasattr(self, "mask") or self.mask is None:
+                    raise RuntimeError(
+                        "--alg_b2b_metric_mask requires B2B inpainting masks."
+                    )
+                if (
+                    hasattr(self, "outputs_per_step")
+                    and isinstance(self.outputs_per_step, dict)
+                    and len(self.outputs_per_step) > 0
+                ):
+                    output_batch_size = next(
+                        iter(self.outputs_per_step.values())
+                    ).shape[0]
+                    batch_metric_masks = self.mask[:output_batch_size].detach()
+                    repeat_dims = [len(self.outputs_per_step)] + [1] * (
+                        batch_metric_masks.ndim - 1
+                    )
+                    batch_metric_masks = batch_metric_masks.repeat(*repeat_dims)
+                else:
+                    batch_metric_masks = self.mask[: self.fake_B.shape[0]].detach()
+                if batch_metric_masks.shape[0] != self.fake_B.shape[0]:
+                    raise RuntimeError(
+                        "B2B metric masks do not align with generated samples: "
+                        f"{batch_metric_masks.shape[0]} masks for "
+                        f"{self.fake_B.shape[0]} outputs."
+                    )
+
             if save_images:
                 pathB = self.save_dir + "/fakeB/%s_epochs_%s_iters_imgs" % (
                     n_epoch,
@@ -1871,6 +1957,8 @@ class BaseModel(ABC):
                     )
 
                 fake_list.append(cur_fake_B.unsqueeze(0).clone())
+                if batch_metric_masks is not None:
+                    mask_list.append(batch_metric_masks[j : j + 1].clone())
 
             if hasattr(self, "gt_image"):
                 batch_real_img = self.gt_image
@@ -1891,6 +1979,8 @@ class BaseModel(ABC):
                 for step, step_fake in self.outputs_per_step.items():
                     fake_list_per_step.setdefault(step, [])
                     real_list_per_step.setdefault(step, [])
+                    if use_b2b_metric_mask:
+                        mask_list_per_step.setdefault(step, [])
 
                     max_batch = min(
                         step_fake.shape[0], batch_real_img_per_step.shape[0]
@@ -1908,6 +1998,10 @@ class BaseModel(ABC):
                                 real_list_per_step[step].append(
                                     batch_real_img_per_step[b, f].detach().clone()
                                 )
+                                if use_b2b_metric_mask:
+                                    mask_list_per_step[step].append(
+                                        self.mask[b, f].detach().clone()
+                                    )
                     else:
                         for b in range(max_batch):
                             fake_list_per_step[step].append(
@@ -1916,6 +2010,10 @@ class BaseModel(ABC):
                             real_list_per_step[step].append(
                                 batch_real_img_per_step[b].detach().clone()
                             )
+                            if use_b2b_metric_mask:
+                                mask_list_per_step[step].append(
+                                    self.mask[b].detach().clone()
+                                )
 
             for i, cur_real in enumerate(batch_real_img):
                 real_list.append(cur_real.unsqueeze(0).clone())
@@ -1962,6 +2060,8 @@ class BaseModel(ABC):
 
         fake_list = fake_list[: self.opt.train_nb_img_max_fid]
         real_list = real_list[: self.opt.train_nb_img_max_fid]
+        if use_b2b_metric_mask:
+            mask_list = mask_list[: self.opt.train_nb_img_max_fid]
 
         if progress:
             progress.close()
@@ -2000,20 +2100,31 @@ class BaseModel(ABC):
             setattr(self, "kidB_test_" + test_name, kidB_test)
         real_tensor = (torch.clamp(torch.cat(real_list), min=-1.0, max=1.0) + 1.0) / 2.0
         fake_tensor = (torch.clamp(torch.cat(fake_list), min=-1.0, max=1.0) + 1.0) / 2.0
+        mask_tensor = torch.cat(mask_list) if use_b2b_metric_mask else None
         if self.opt.G_netG in ["unet_vid", "vit_vid"]:  # temporal
-            real_tensor, fake_tensor = rearrange_5dto4d_bf(real_tensor, fake_tensor)
-            ssim_test = ssim(real_tensor, fake_tensor)
-            psnr_test = psnr(real_tensor, fake_tensor)
-
-            psnr_each = psnr(real_tensor, fake_tensor, reduction="none")  # [B]
-
-            psnr_list = psnr_each[
-                psnr_each < 78
-            ]  # with this PIQ code, identical images give 80
-            if psnr_list.numel() > 0:
-                psnr_test = psnr_list.mean()
+            if use_b2b_metric_mask:
+                real_tensor, fake_tensor, mask_tensor = rearrange_5dto4d_bf(
+                    real_tensor, fake_tensor, mask_tensor
+                )
             else:
-                psnr_test = psnr_each.mean()
+                real_tensor, fake_tensor = rearrange_5dto4d_bf(real_tensor, fake_tensor)
+            ssim_test = ssim(real_tensor, fake_tensor)
+            if use_b2b_metric_mask:
+                psnr_test = self._compute_masked_psnr(
+                    real_tensor, fake_tensor, mask_tensor, filter_psnr_78=True
+                )
+            else:
+                psnr_test = psnr(real_tensor, fake_tensor)
+
+                psnr_each = psnr(real_tensor, fake_tensor, reduction="none")  # [B]
+
+                psnr_list = psnr_each[
+                    psnr_each < 78
+                ]  # with this PIQ code, identical images give 80
+                if psnr_list.numel() > 0:
+                    psnr_test = psnr_list.mean()
+                else:
+                    psnr_test = psnr_each.mean()
 
             if getattr(self.opt, "alg_palette_metric_mask", False) or getattr(
                 self.opt, "alg_cm_metric_mask", False
@@ -2091,7 +2202,12 @@ class BaseModel(ABC):
 
         else:  # image
             ssim_test = ssim(real_tensor, fake_tensor)
-            psnr_test = psnr(real_tensor, fake_tensor)
+            if use_b2b_metric_mask:
+                psnr_test = self._compute_masked_psnr(
+                    real_tensor, fake_tensor, mask_tensor
+                )
+            else:
+                psnr_test = psnr(real_tensor, fake_tensor)
 
             if getattr(self.opt, "alg_palette_metric_mask", False) or getattr(
                 self.opt, "alg_cm_metric_mask", False
@@ -2196,10 +2312,19 @@ class BaseModel(ABC):
                     continue
 
                 max_count = min(len(fake_images), len(gt_images))
+                masks = None
+                if use_b2b_metric_mask:
+                    masks = mask_list_per_step.get(step, [])
+                    if len(masks) < max_count:
+                        raise RuntimeError(
+                            "B2B per-step metric masks do not align with generated "
+                            f"samples at step {step}."
+                        )
                 psnr_val, ssim_val, lpips_val, dinov2_val = self._compute_metrics(
                     fake_images[:max_count],
                     gt_images[:max_count],
                     filter_psnr_78=filter_psnr_78,
+                    masks=masks[:max_count] if masks is not None else None,
                 )
 
                 self.psnr_step[step] = psnr_val

--- a/tests/test_b2b_masked_psnr.py
+++ b/tests/test_b2b_masked_psnr.py
@@ -1,0 +1,110 @@
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import models.base_model as base_model_module
+from models.base_model import BaseModel
+from util.util import MAX_INT
+
+
+class B2BMetricModel:
+    def __init__(self, use_mask):
+        self.opt = SimpleNamespace(
+            train_nb_img_max_fid=MAX_INT,
+            model_type="b2b",
+            alg_b2b_metric_mask=use_mask,
+            isTrain=True,
+            test_batch_size=1,
+            G_netG="vit_vid",
+            data_direction="AtoB",
+            train_metrics_list=["PSNR"],
+        )
+        self.use_temporal = False
+        self.use_inception = False
+        self.visual_names = []
+
+    def _is_b2b_validation_loss_enabled(self):
+        return False
+
+    _compute_masked_psnr = staticmethod(BaseModel._compute_masked_psnr)
+
+    def _compute_metrics(self, *args, **kwargs):
+        return BaseModel._compute_metrics(self, *args, **kwargs)
+
+    def set_input(self, data):
+        self.gt_image = data["real"]
+        self.real_B = self.gt_image
+        self.mask = data["mask"]
+        self.step_outputs = data["step_outputs"]
+
+    def inference(self, _batch_size, offset=0):
+        del offset
+        self.outputs_per_step = self.step_outputs
+        self.fake_B = torch.cat(list(self.outputs_per_step.values()), dim=0)
+        self.gt_image = self.gt_image.repeat(len(self.outputs_per_step), 1, 1, 1, 1)
+
+
+def _metric_batch():
+    real = torch.zeros(1, 2, 3, 2, 2)
+    mask = torch.zeros(1, 2, 1, 2, 2)
+    mask[:, 1, :, 0, 0] = 1
+
+    step_2 = torch.ones_like(real)
+    step_5 = torch.ones_like(real)
+    step_5[:, 1, :, 0, 0] = 0.5
+    return {
+        "real": real,
+        "mask": mask,
+        "step_outputs": {2: step_2, 5: step_5},
+    }
+
+
+def _patch_full_crop_metrics(monkeypatch, psnr_value=42.0):
+    monkeypatch.setattr(
+        base_model_module, "ssim", lambda _real, _fake: torch.tensor(1.0)
+    )
+
+    def fake_psnr(real, _fake, reduction="mean", **_kwargs):
+        if reduction == "none":
+            return torch.full((real.shape[0],), psnr_value)
+        return torch.tensor(psnr_value)
+
+    monkeypatch.setattr(base_model_module, "psnr", fake_psnr)
+
+
+def test_masked_psnr_uses_only_masked_pixels_and_skips_empty_masks():
+    real = torch.zeros(3, 3, 2, 2)
+    fake = torch.ones_like(real)
+    mask = torch.zeros(3, 1, 2, 2)
+
+    mask[0, :, 0, 0] = 1
+    fake[0, :, 0, 0] = 0.5
+    mask[1] = 1
+    fake[1] = 0.5
+
+    result = BaseModel._compute_masked_psnr(real, fake, mask)
+
+    assert result.item() == pytest.approx(10 * math.log10(4))
+
+
+def test_b2b_metric_mask_applies_to_global_and_per_step_psnr(monkeypatch):
+    _patch_full_crop_metrics(monkeypatch)
+    model = B2BMetricModel(use_mask=True)
+
+    BaseModel.compute_metrics_test(model, [(_metric_batch(),)], 1, 1000)
+
+    assert model.psnr_test_.item() == pytest.approx(9.030899, rel=1e-5)
+    assert model.psnr_step_results[""][2] == pytest.approx(6.0206, rel=1e-5)
+    assert model.psnr_step_results[""][5] == pytest.approx(12.0412, rel=1e-5)
+
+
+def test_b2b_metric_mask_disabled_keeps_full_crop_psnr(monkeypatch):
+    _patch_full_crop_metrics(monkeypatch)
+    model = B2BMetricModel(use_mask=False)
+
+    BaseModel.compute_metrics_test(model, [(_metric_batch(),)], 1, 1000)
+
+    assert model.psnr_test_.item() == pytest.approx(42.0)
+    assert model.psnr_step_results[""] == {2: 42.0, 5: 42.0}

--- a/tests/test_temporal_test_sampling.py
+++ b/tests/test_temporal_test_sampling.py
@@ -1,0 +1,67 @@
+import pytest
+
+from data.self_supervised_vid_labeled_mask_cls_online_dataset import (
+    SelfSupervisedVidLabeledMaskClsOnlineDataset,
+)
+from data.self_supervised_vid_mask_online_dataset import (
+    SelfSupervisedVidMaskOnlineDataset,
+)
+from data.temporal_sampling import build_temporal_series_index
+
+
+@pytest.mark.parametrize(
+    "dataset_class",
+    [
+        SelfSupervisedVidMaskOnlineDataset,
+        SelfSupervisedVidLabeledMaskClsOnlineDataset,
+    ],
+)
+def test_temporal_test_sampling_visits_every_valid_window_once(dataset_class):
+    paths = [
+        "video_a/frame_000.jpg",
+        "video_a/frame_001.jpg",
+        "video_a/frame_002.jpg",
+        "video_b/frame_000.jpg",
+        "video_b/frame_001.jpg",
+        "video_b/frame_002.jpg",
+        "video_b/frame_003.jpg",
+    ]
+    series_index = build_temporal_series_index(paths, num_frames=2, frame_step=1)
+
+    dataset = object.__new__(dataset_class)
+    dataset.phase = "test"
+    dataset.frame_step_random_max = 0
+    dataset.A_img_paths = paths
+    dataset.A_size = len(paths)
+    (
+        dataset.vid_series_paths,
+        dataset.frames_counts,
+        dataset.cumulative_sums,
+        dataset.available_frame_pool,
+    ) = series_index
+
+    assert len(dataset) == 5
+    assert [
+        dataset._select_temporal_index_A(frame_step=1, dataset_index=index)
+        for index in range(len(dataset))
+    ] == [0, 1, 3, 4, 5]
+
+
+def test_temporal_test_sampling_rejects_index_past_valid_windows():
+    paths = ["video/frame_000.jpg", "video/frame_001.jpg"]
+    series_index = build_temporal_series_index(paths, num_frames=2, frame_step=1)
+
+    dataset = object.__new__(SelfSupervisedVidMaskOnlineDataset)
+    dataset.phase = "test"
+    dataset.frame_step_random_max = 0
+    dataset.A_img_paths = paths
+    dataset.A_size = len(paths)
+    (
+        dataset.vid_series_paths,
+        dataset.frames_counts,
+        dataset.cumulative_sums,
+        dataset.available_frame_pool,
+    ) = series_index
+
+    with pytest.raises(IndexError, match="outside"):
+        dataset._select_temporal_index_A(frame_step=1, dataset_index=1)


### PR DESCRIPTION
## Summary

  - Add opt-in `--alg_b2b_metric_mask` support to calculate B2B PSNR only over positive pixels of the exact input/inpainting mask.
  - Apply masked PSNR to aggregate and per-denoising-step results.
  - Enumerate every valid temporal test window exactly once when using a fixed frame step.
  - Keep training-time temporal sampling random.
  - Preserve full-crop PSNR when the option is disabled.
  - Leave SSIM and LPIPS behavior unchanged.

  ## Motivation

  Previously, B2B PSNR was calculated over the complete crop, including the unchanged background. Temporal test sampling could also repeat some windows and omit others.

  This change makes masked PSNR representative of inpainting quality and ensures complete,deterministic temporal test coverage.

  ## Validation

  - Black formatting check passed.
  - Focused tests passed: `7 passed`.
  - Verified that a 12-frame test sequence with two-frame inputs and frame step 1 evaluates
  all 11 valid temporal windows.
