### PR TITLE
feat: add optional fixed temporal init noise

### DIFF
--- a/scripts/b2b_onnx_denoiser_infer_autoregressive_progress_bbox.py
+++ b/scripts/b2b_onnx_denoiser_infer_autoregressive_progress_bbox.py
@@ -1570,12 +1570,14 @@ def run_sequence(
     denoise_steps,
     debug_dump_dir,
     autoregressive_reinject_patch,
+    fixed_temporal_init_noise=False,
     object_refs=None,
     temporal_frame_step=None,
     mask_precision_mode=None,
     mask_precision_severity=None,
     apply_predicted_mask=False,
     use_predicted_mask_during_denoising=False,
+    source_crop_size=None,
 ):
     rng = np.random.default_rng(seed)
     _, _, _, output_h, output_w = get_train_shape(train_json)
@@ -1592,6 +1594,7 @@ def run_sequence(
     last_seq_half_mask = None
     last_seq_half_mandatory_mask = None
     last_seq_half_global_context = None
+    fixed_window_noise = None
     frames_written = []
     seq_half = 1
     num_buckets = 2
@@ -1608,6 +1611,7 @@ def run_sequence(
             device=torch.device("cpu"),
             mask_precision_mode=precision_mode_id,
             mask_precision_severity=precision_severity_value,
+            crop_size_override=source_crop_size,
         )
         frame_data["index"] = sequence_count
         frame_data["img_rel"] = img_rel
@@ -1682,7 +1686,14 @@ def run_sequence(
                 autoregressive_reinject_patch and last_seq_half_y_t is not None
             ),
         )
-        init_noise = rng.standard_normal(size=y_t_batch.shape, dtype=np.float32)
+        if fixed_temporal_init_noise:
+            if fixed_window_noise is None:
+                fixed_window_noise = rng.standard_normal(
+                    size=y_t_batch.shape, dtype=np.float32
+                )
+            init_noise = fixed_window_noise
+        else:
+            init_noise = rng.standard_normal(size=y_t_batch.shape, dtype=np.float32)
         restoration_result = restoration_with_denoiser(
             session=session,
             y=y_t_batch.numpy().astype(np.float32),
@@ -1855,6 +1866,15 @@ def parse_args():
     parser.add_argument("--label", type=int, default=None, help="Override class label")
     parser.add_argument("--seed", type=int, default=0, help="Seed for init_noise")
     parser.add_argument(
+        "--fixed_temporal_init_noise",
+        "--fixed-temporal-init-noise",
+        action="store_true",
+        help=(
+            "Reuse one seeded two-frame noise field for every sliding window. "
+            "Use with autoregressive reinjection to test temporal stability."
+        ),
+    )
+    parser.add_argument(
         "--mask_precision_mode",
         "--mask-precision-mode",
         choices=sorted(MASK_PRECISION_NAMES),
@@ -2013,6 +2033,7 @@ def main():
         denoise_steps=denoise_steps,
         debug_dump_dir=args.debug_dump_dir,
         autoregressive_reinject_patch=args.autoregressive_reinject_patch,
+        fixed_temporal_init_noise=args.fixed_temporal_init_noise,
         temporal_frame_step=args.temporal_frame_step,
         object_refs=object_refs,
         mask_precision_mode=args.mask_precision_mode,
@@ -2035,6 +2056,7 @@ def main():
     print(f"mask_precision: {(precision_mode, precision_severity)}")
     print(f"object_refs  : {0 if object_refs is None else int(object_refs.shape[0])}")
     print(f"autoregressive_reinject_patch: {args.autoregressive_reinject_patch}")
+    print(f"fixed_temporal_init_noise: {args.fixed_temporal_init_noise}")
     print(f"apply_predicted_mask: {args.apply_predicted_mask}")
     print(
         "use_predicted_mask_during_denoising: "

--- a/scripts/b2b_pth_denoiser_infer_autoregressive_progress_bbox.py
+++ b/scripts/b2b_pth_denoiser_infer_autoregressive_progress_bbox.py
@@ -199,6 +199,15 @@ def parse_args():
     parser.add_argument("--label", type=int, default=None, help="Override class label")
     parser.add_argument("--seed", type=int, default=0, help="Seed for init_noise")
     parser.add_argument(
+        "--fixed_temporal_init_noise",
+        "--fixed-temporal-init-noise",
+        action="store_true",
+        help=(
+            "Reuse one seeded two-frame noise field for every sliding window. "
+            "Use with autoregressive reinjection to test temporal stability."
+        ),
+    )
+    parser.add_argument(
         "--mask_precision_mode",
         "--mask-precision-mode",
         choices=sorted(onnx_runner.MASK_PRECISION_NAMES),
@@ -223,6 +232,15 @@ def parse_args():
         "--denoise_steps",
         type=int,
         help="Override denoise step count. Defaults to first entry from alg.b2b_denoise_timesteps",
+    )
+    parser.add_argument(
+        "--source_crop_size",
+        "--source-crop-size",
+        type=int,
+        help=(
+            "Inference-only square source crop size before resizing to the saved "
+            "model resolution. Defaults to data.online_creation.crop_size_A."
+        ),
     )
     parser.add_argument(
         "--device",
@@ -330,12 +348,14 @@ def main():
         denoise_steps=denoise_steps,
         debug_dump_dir=args.debug_dump_dir,
         autoregressive_reinject_patch=args.autoregressive_reinject_patch,
+        fixed_temporal_init_noise=args.fixed_temporal_init_noise,
         object_refs=object_refs,
         temporal_frame_step=args.temporal_frame_step,
         mask_precision_mode=args.mask_precision_mode,
         mask_precision_severity=args.mask_precision_severity,
         apply_predicted_mask=args.apply_predicted_mask,
         use_predicted_mask_during_denoising=(args.use_predicted_mask_during_denoising),
+        source_crop_size=args.source_crop_size,
     )
 
     print(f"dataset_root : {dataset_root}")
@@ -344,6 +364,10 @@ def main():
     print(f"device       : {device}")
     print(f"train_shape  : {(train_frames, train_height, train_width)}")
     print(f"denoise_steps: {denoise_steps}")
+    print(
+        "source_crop_size: "
+        f"{args.source_crop_size if args.source_crop_size is not None else 'saved crop_size_A'}"
+    )
     print(
         "temporal_frame_step: "
         f"{onnx_runner.resolve_temporal_frame_step(train_json, args.temporal_frame_step)}"
@@ -356,6 +380,7 @@ def main():
     )
     print(f"mask_precision: {(precision_mode, precision_severity)}")
     print(f"autoregressive_reinject_patch: {args.autoregressive_reinject_patch}")
+    print(f"fixed_temporal_init_noise: {args.fixed_temporal_init_noise}")
     print(f"apply_predicted_mask: {args.apply_predicted_mask}")
     print(
         "use_predicted_mask_during_denoising: "


### PR DESCRIPTION
## Summary

  Add an opt-in fixed temporal initialization noise mode for B2B autoregressive inference.

  - Add `--fixed-temporal-init-noise` / `--fixed_temporal_init_noise` to the ONNX and PTH inference runners.
  - When enabled, reuse one seeded two-frame noise tensor for all autoregressive windows.
  - Default behavior is unchanged: fresh seeded noise is sampled for each window.
  - Add PTH `--source-crop-size` as an inference-only override before resize.

  ## Why

  The fixed-noise option makes it possible to compare temporal stability against the normal fresh-noise sampler under otherwise identical settings.

  ## Validation

  - Both modified Python scripts compile successfully.
  - Both `--help` outputs expose the new fixed-noise flag.
  - PTH runner also exposes `--source-crop-size`.

  ## Backward compatibility

  No behavior changes unless `--fixed-temporal-init-noise` or `--source-crop-size` is explicitly supplied.
